### PR TITLE
fix: desktopCapturer in electron 17+ (fixes #59)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   ipcMain,
   session,
   dialog,
+  desktopCapturer,
 } from 'electron';
 
 import { emptyDirSync, ensureFileSync } from 'fs-extra';
@@ -631,6 +632,11 @@ ipcMain.on('set-spellchecker-locales', (_e, { locale, serviceId }) => {
   debug(`Setting spellchecker locales to: ${locales}`);
   serviceSession.setSpellCheckerLanguages(locales);
 });
+
+
+ipcMain.handle('get-desktop-capturer-sources', () => desktopCapturer.getSources({
+  types: ['screen', 'window'],
+}));
 
 ipcMain.on('window.toolbar-double-clicked', () => {
   mainWindow?.isMaximized() ? mainWindow.unmaximize() : mainWindow?.maximize();

--- a/src/webview/screenshare.ts
+++ b/src/webview/screenshare.ts
@@ -1,11 +1,9 @@
-import { desktopCapturer } from 'electron';
+import { ipcRenderer } from 'electron';
 
 const CANCEL_ID = 'desktop-capturer-selection__cancel';
 
 export async function getDisplayMediaSelector() {
-  const sources = await desktopCapturer.getSources({
-    types: ['screen', 'window'],
-  });
+  const sources = await ipcRenderer.invoke('get-desktop-capturer-sources');
   return `<div class="desktop-capturer-selection__scroller">
   <ul class="desktop-capturer-selection__list">
     ${sources


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This patch adds a new IPC message from the service renderer to the main process so it can still invoke `desktopCapturer.getSources` as per https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer

#### Motivation and Context
Since electron 17, `desktopCapturer` is only available in the main process: https://www.electronjs.org/blog/electron-17-0#desktopcapturergetsources-in-the-renderer

This should fix #59 and maybe also #32.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fixed screen sharing in services
