### PR TITLE
feat: add CSS scroll snap in split view mode

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -95,6 +95,7 @@ body.win32:not(.isFullScreen) .app .app__content {
 
 .mode__split .app .app__service {
   overflow-x: auto;
+  scroll-snap-type: x proximity;
 }
 
 .app {

--- a/src/styles/services.scss
+++ b/src/styles/services.scss
@@ -26,6 +26,7 @@
     .services__webview {
       position: relative;
       flex: 1 0 33.3333%;
+      scroll-snap-align: start;
     }
   }
 


### PR DESCRIPTION
This PR adds CSS scroll snapping to panes when scrolling horizontally in split view mode.