### PR TITLE
fix: modify user agent string on Linux

### DIFF
--- a/src/helpers/userAgent-helpers.ts
+++ b/src/helpers/userAgent-helpers.ts
@@ -28,7 +28,7 @@ function windows() {
 
 function linux() {
   const archString = is64Bit ? 'x86_64' : osArch;
-  return `X11; Ubuntu; Linux ${archString}`;
+  return `X11; Linux ${archString}`;
 }
 
 export default function userAgent() {


### PR DESCRIPTION
On Linux, the user agent includes 'X11; Ubuntu; Linux ${arch}'.

On my non-Ubuntu Linux machine, the UA used is almost identical, except
for the 'Ubuntu; ' part. Removing that part from the default UA we use
fixes that particular error and seems no to break any other services.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Removed `Ubuntu; ` from the user agent generated on Linux machines.

#### Motivation and Context
The user agent string breaks the Google Calendar service because the server decides to serve to mobile site instead of the desktop site based on that string.

Removing the `Ubuntu; ` brings the UA in line with what my Chrome is using on a non-Ubuntu Linux machine. This also makes the UA "more correct" since not everybody using Linux is on Ubuntu. This fixes the issue and seems to not break anything else.

I think this is a sensible change to make here instead of using a "custom" user agent for the `googlecalendar` recipe.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Remove "Ubuntu" from the Linux user agent string (fixes Google Calendar showing the mobile page)
