### PR TITLE
Add a custom 'About' dialog - so that we can select & copy the text in linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import { DEFAULT_APP_SETTINGS, DEFAULT_WINDOW_OPTIONS } from './config';
 import { isMac, isWindows, isLinux, altKey } from './environment';
 import {
   isDevMode,
-  aboutAppDetails,
   userDataRecipesPath,
   userDataPath,
 } from './environment-remote';
@@ -166,11 +165,6 @@ if (!retrieveSettingValue('enableGPUAcceleration', false)) {
   debug('Disable GPU Acceleration');
   app.disableHardwareAcceleration();
 }
-
-app.setAboutPanelOptions({
-  applicationVersion: aboutAppDetails(),
-  version: '',
-});
 
 const createWindow = () => {
   // Remember window size

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -740,14 +740,30 @@ class FranzMenu {
       );
     }
 
+    const about = {
+      label: intl.formatMessage(menuItems.about),
+      click: () => {
+        dialog.showMessageBox({
+          type: 'info',
+          title: app.name,
+          message: app.name,
+          detail: aboutAppDetails(),
+          buttons: ['Close'],
+          // TODO: Can add a 'Copy' button with the following clickHandler
+          // click: () => {
+          //   clipboard.write({
+          //     text: aboutAppDetails(),
+          //   });
+          // }
+        });
+      },
+    };
+
     tpl.unshift({
       label: isMac ? app.name : intl.formatMessage(menuItems.file),
       accelerator: `${altKey()}+F`,
       submenu: [
-        {
-          label: intl.formatMessage(menuItems.about),
-          role: 'about',
-        },
+        about,
         {
           type: 'separator',
         },
@@ -804,20 +820,8 @@ class FranzMenu {
       ],
     });
 
-    const about = {
-      label: intl.formatMessage(menuItems.about),
-      click: () => {
-        dialog.showMessageBox({
-          type: 'info',
-          title: 'Ferdium',
-          message: 'Ferdium',
-          detail: aboutAppDetails(),
-        });
-      },
-    };
-
     if (isMac) {
-      // Edit menu.
+      // Edit menu
       tpl[1].submenu.push(
         {
           type: 'separator',


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Use a custom modal dialog box for the `About` dialog - common for all OSes (not the electron default one)

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
Linux users should be able to select & copy the text in the `About` Dialog.

#### Notes
I am not sure which is better: 
1. The old one (on mac) is not modal, while the new one is modal.
2. The old one had a titlebar with the 3 buttons in any macos window - but, maybe this is a side-effect of the first point.
3. The old one can be closed with the `Esc` key, while the new one does not respond to `Esc` keystroke. If we need to support this, then we will need to attach a keyhandler to accomplish this?

#### Screenshots
<!-- Remove the section if this does not apply. -->
These are the screenshots of the `About` dialog in macos:
Old:
<img width="283" alt="Screenshot 2022-05-08 at 3 25 01 PM" src="https://user-images.githubusercontent.com/69629/167314516-a026762f-82e7-4ba9-bb26-b2fd434f2167.png">
New:
<img width="256" alt="Screenshot 2022-05-08 at 3 24 05 PM" src="https://user-images.githubusercontent.com/69629/167314521-622b4b02-91ac-47c9-a813-c603c01c60c0.png">


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
