### PR TITLE
Align 'Save service' button to right when adding recipe

### DIFF
--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -490,7 +490,9 @@ class EditServiceForm extends Component {
         </div>
         <div className="settings__controls">
           {/* Delete Button */}
-          {action === 'edit' && deleteButton}
+          <div>
+            {action === 'edit' && deleteButton}
+          </div>
 
           {/* Save Button */}
           {isSaving || isValidatingCustomUrl ? (

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -370,9 +370,6 @@
     }
   }
 
-  .settings__delete-button {
-    right: 0;
-  }
   .settings__open-recipe-file-button, .settings__open-settings-file-button {
     cursor: pointer;
     margin-right: 10px;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Align 'Save service' button to right when adding recipe

#### Motivation and Context
The 'Save service' button was aligned to right when adding recipe. This was not the behavior of some nighties ago, I believe.

#### Screenshots
| Before: ![image](https://user-images.githubusercontent.com/37463445/171414668-8a008ac3-b313-48ec-b124-a467286d595a.png)   | After:  ![image](https://user-images.githubusercontent.com/37463445/171414715-51d24b15-2c2e-4813-bbaf-f50607233681.png) |
|---|---|


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Align 'Save service' button to right when adding recipe
