### PR TITLE
fix: webview did-attach race condition

### DIFF
--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -95,10 +95,18 @@ class ServiceWebview extends Component {
         preload={preloadScript}
         partition={service.partition}
         onDidAttach={() => {
-          setWebviewReference({
-            serviceId: service.id,
-            webview: this.webview.view,
-          });
+          // Force the event handler to run in a new task.
+          // This resolves a race condition when the `did-attach` is called,
+          // but the webview is not attached to the DOM yet:
+          // https://github.com/electron/electron/issues/31918
+          // This prevents us from immediately attaching listeners such as `did-stop-load`:
+          // https://github.com/ferdium/ferdium-app/issues/157
+          setTimeout(() => {
+            setWebviewReference({
+              serviceId: service.id,
+              webview: this.webview.view,
+            });
+          }, 0);
         }}
         onUpdateTargetUrl={this.updateTargetUrl}
         useragent={service.userAgent}


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Make sure the event handler for attached webviews runs in a separate task to avoid race conditions like https://github.com/electron/electron/issues/31918

If a new task is not sufficient, we can try a nonzero timeout (in the ballpark of 10 ms). But hopefully, the race condition is merely between different tasks in the queue in the renderer process, and we don't have to actually wait for some internal Electron IPC to complete.

Worst comes to worst, we could change this to poll until the webview manages to attach, but that would be quite annoying.

#### Motivation and Context
This should hopefully fix #157, but the race conditions are tricky to debug, so we'll need some more testing. Nevertheless, I couldn't trigger the bug locally after this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Fix stuck loading indicator on services (#157)
