### PR TITLE
fix: disable todos feature by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -191,8 +191,9 @@ export const DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED = false;
 
 export const DEFAULT_TODOS_WIDTH = 300;
 export const TODOS_MIN_WIDTH = 200;
-export const DEFAULT_TODOS_VISIBLE = true;
+export const DEFAULT_TODOS_VISIBLE = false;
 export const DEFAULT_IS_FEATURE_ENABLED_BY_USER = true;
+export const DEFAULT_IS_TODO_FEATURE_ENABLED_BY_USER = false;
 export const TODOS_PARTITION_ID = 'persist:todos';
 
 export const CUSTOM_WEBSITE_RECIPE_ID = 'franz-custom-website';

--- a/src/features/todos/store.js
+++ b/src/features/todos/store.js
@@ -9,7 +9,7 @@ import {
   DEFAULT_TODOS_WIDTH,
   TODOS_MIN_WIDTH,
   DEFAULT_TODOS_VISIBLE,
-  DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+  DEFAULT_IS_TODO_FEATURE_ENABLED_BY_USER,
 } from '../../config';
 import { isValidExternalURL } from '../../helpers/url-helpers';
 import { FeatureStore } from '../utils/FeatureStore';
@@ -267,7 +267,7 @@ export default class TodoStore extends FeatureStore {
 
     if (this.settings.isFeatureEnabledByUser === undefined) {
       this._updateSettings({
-        isFeatureEnabledByUser: DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+        isFeatureEnabledByUser: DEFAULT_IS_TODO_FEATURE_ENABLED_BY_USER,
       });
     }
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Disable the TODO feature by default and let the user enable it themselves.

#### Motivation and Context
- Valid feedback from Reddit
- Open discussion about it on Discord :)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
- Disable the TODO feature by default and let the user enable it themselves.