### PR TITLE
chore: improve todo menu behaviour on fresh install

### DIFF
--- a/src/I18n.tsx
+++ b/src/I18n.tsx
@@ -11,7 +11,7 @@ const translations = generatedTranslations();
 type Props = {
   stores: {
     app: AppStore;
-    user: typeof UserStore;
+    user: UserStore;
   };
   children: ReactNode;
 };

--- a/src/features/todos/store.js
+++ b/src/features/todos/store.js
@@ -206,8 +206,10 @@ export default class TodoStore extends FeatureStore {
   @action _toggleTodosFeatureVisibility = () => {
     debug('_toggleTodosFeatureVisibility');
 
+    const isFeatureEnabled = !this.settings.isFeatureEnabledByUser;
     this._updateSettings({
-      isFeatureEnabledByUser: !this.settings.isFeatureEnabledByUser,
+      isFeatureEnabledByUser: isFeatureEnabled,
+      isTodosPanelVisible: isFeatureEnabled,
     });
   };
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -473,15 +473,18 @@ const _titleBarTemplateFactory = (intl, locked) => [
         accelerator: `${cmdOrCtrlShortcutKey()}+B`,
         role: 'toggleNavigationBar',
         type: 'checkbox',
-        checked: window['ferdium'].stores.settings.app.navigationBarManualActive,
+        checked:
+          window['ferdium'].stores.settings.app.navigationBarManualActive,
         click: () => {
           window['ferdium'].actions.settings.update({
             type: 'app',
             data: {
-              navigationBarManualActive: !window['ferdium'].stores.settings.app.navigationBarManualActive,
-            }
+              navigationBarManualActive:
+                !window['ferdium'].stores.settings.app
+                  .navigationBarManualActive,
+            },
           });
-        }
+        },
       },
       {
         label: intl.formatMessage(menuItems.splitModeToggle),
@@ -494,9 +497,9 @@ const _titleBarTemplateFactory = (intl, locked) => [
             type: 'app',
             data: {
               splitMode: !window['ferdium'].stores.settings.app.splitMode,
-            }
+            },
           });
-        }
+        },
       },
       {
         label: intl.formatMessage(menuItems.toggleDarkMode),
@@ -631,9 +634,10 @@ class FranzMenu {
     }
 
     const { intl } = window['ferdium'];
-    const locked = this.stores.settings.app.locked
-      && this.stores.settings.app.lockingFeatureEnabled
-      && this.stores.user.isLoggedIn;
+    const locked =
+      this.stores.settings.app.locked &&
+      this.stores.settings.app.lockingFeatureEnabled &&
+      this.stores.user.isLoggedIn;
     const tpl = _titleBarTemplateFactory(intl, locked);
     const { actions } = this;
 
@@ -664,8 +668,9 @@ class FranzMenu {
           accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+I`,
           click: () => {
             const windowWebContents = webContents.fromId(1);
-            const { isDevToolsOpened, openDevTools, closeDevTools } = windowWebContents;
-    
+            const { isDevToolsOpened, openDevTools, closeDevTools } =
+              windowWebContents;
+
             if (isDevToolsOpened()) {
               closeDevTools();
             } else {
@@ -1105,14 +1110,16 @@ class FranzMenu {
       ? menuItems.closeTodosDrawer
       : menuItems.openTodosDrawer;
 
-    menu.push({
-      label: intl.formatMessage(drawerLabel),
-      accelerator: `${todosToggleShortcutKey()}`,
-      click: () => {
-        todoActions.toggleTodosPanel();
-      },
-      enabled: this.stores.user.isLoggedIn && isFeatureEnabledByUser,
-    });
+    if (isFeatureEnabledByUser) {
+      menu.push({
+        label: intl.formatMessage(drawerLabel),
+        accelerator: `${todosToggleShortcutKey()}`,
+        click: () => {
+          todoActions.toggleTodosPanel();
+        },
+        enabled: this.stores.user.isLoggedIn && isFeatureEnabledByUser,
+      });
+    }
 
     if (!isFeatureEnabledByUser) {
       menu.push(
@@ -1124,6 +1131,7 @@ class FranzMenu {
           click: () => {
             todoActions.toggleTodosFeatureVisibility();
           },
+          enabled: this.stores.user.isLoggedIn,
         },
       );
     }
@@ -1155,7 +1163,9 @@ class FranzMenu {
       {
         label: intl.formatMessage(menuItems.publishDebugInfo),
         click: () => {
-          window['ferdium'].features.publishDebugInfo.state.isModalVisible = true;
+          window[
+            'ferdium'
+          ].features.publishDebugInfo.state.isModalVisible = true;
         },
       },
     ];


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Updated behaviour of the todos menu:

1. Open/Close drawer is only shown when having the feature enabled
2. Enabling the feature will directly open the drawer which means 1 less click

However, during working on this issue I discovered a bigger issue regarding the menu rebuild which I created another issue for in #358

#### Motivation and Context
This adds improvement to the change in #355 and helps solve an issue from #269 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally
