### PR TITLE
fix: bring the draggable area back on MacOS

### DIFF
--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -65,7 +65,7 @@ const styles = theme => ({
     display: 'block',
     zIndex: 1,
     width: '100%',
-    height: '29px',
+    height: '10px',
     position: 'absolute',
     top: 0,
   },
@@ -124,14 +124,14 @@ class AppLayout extends Component {
 
     const { intl } = this.props;
 
-    const { locked, automaticUpdates, showDragArea } = settings.app;
+    const { locked, automaticUpdates } = settings.app;
     if (locked) {
       return <LockedScreen />;
     }
 
     return (
       <>
-      {isMac && !isFullScreen && showDragArea && (
+      {isMac && !isFullScreen && (
         <div className="window-draggable" />
       )}
       <ErrorBoundary>
@@ -142,7 +142,7 @@ class AppLayout extends Component {
               icon="assets/images/logo.svg"
             />
           )}
-          {isMac && !isFullScreen && showDragArea && (
+          {isMac && !isFullScreen && (
             <span
               onDoubleClick={toggleFullScreen}
               className={classes.titleBar}


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This change brings the "invisible" draggable area back on macOS, the reason this was removed was that the elements behind it weren't clickable anymore. However, the reason this was happening wasn't actually because of the draggable area but because of the feature that enables the window to be maximized by double-clicking that area (hence the capturing of click events). 

My proposed solution is to bring the draggable area back and reduce the double-click area to 10px which increases the area where you can click and expect the normal behaviour.

#### Motivation and Context
- To improve UX and allow the window to be dragged while on macOS without visible draggable area

This should fix:
- #370 
- #347 
- While still keeping #348 happy as well

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally
