### PR TITLE
chore: recommend specific vscode extensions to setup development [skip ci]

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+      "esbenp.prettier-vscode",
+      "dbaeumer.vscode-eslint",
+      "codezombiech.gitignore",
+      "EditorConfig.EditorConfig"
+    ]
+}


### PR DESCRIPTION
#### Description of Change
Based on the project setup and contributing.md I'd like to suggest a couple of basic vscode plugins to the ./vscode/extensions.json to let vscode inform people of which plugins to use. 

#### Motivation and Context
So that everyone that uses vscode will be advised to install these plugins, and get all the benefit of the prettier/eslint/gitignore/editorconfig files in the editor.