### PR TITLE
fix: don't break when when service is undefined on adding a new service

### DIFF
--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -247,9 +247,9 @@ class EditServiceForm extends Component {
     );
 
     let activeTabIndex = 0;
-    if (recipe.hasHostedOption && service.team) {
+    if (recipe.hasHostedOption && service?.team) {
       activeTabIndex = 1;
-    } else if (recipe.hasHostedOption && service.customUrl) {
+    } else if (recipe.hasHostedOption && service?.customUrl) {
       activeTabIndex = 2;
     }
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Minor change by checking if service is set or otherwise return undefined.

#### Motivation and Context
It's currently broken to add a service which also contains a hosted option of the service (like jira).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally
