### PR TITLE
Moved tagging of the repo from the nightly build process to the post-…

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -46,7 +46,6 @@ jobs:
           ref: nightly
           submodules: recursive
           fetch-depth: 0 # Note: Needed to be able to pull the 'develop' branch as well for merging
-          # ssh-key: ${{ secrets.FERDIUM_PUBLISH_TOKEN }}
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
@@ -77,15 +76,9 @@ jobs:
             #   there were other changes coming from the 'develop' branch (or)
             #   this is a manual trigger with the key-phrase
             git checkout develop
-            TAG_NAME=$(npm version -m "%s [skip ci]" prerelease --preid=nightly)
+            npm version -m "%s [skip ci]" prerelease --preid=nightly
             git commit --all --amend --no-edit --no-verify
             git push origin develop --no-verify
-            git tag -f $TAG_NAME
-            git push origin --tags --no-verify
-            # Also tag the submodule so as to help identify which changes went into which nightly release
-            # TODO: Not working due to cross-repo access issues by the github-action bot
-            # git -C recipes tag -f $TAG_NAME
-            # git -C recipes push origin --tags --no-verify
 
             git checkout nightly
           fi

--- a/.github/workflows/tag-repos.yml
+++ b/.github/workflows/tag-repos.yml
@@ -1,0 +1,35 @@
+name: Tag all repos
+
+on:
+  release:
+    types: [published]
+  # Manual trigger from the UI
+  workflow_dispatch:
+
+jobs:
+  bump-casks:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled'
+      uses: actions/checkout@v3
+      if: ${{ contains(github.event.release.tag_name, 'nightly') }}
+      with:
+        ref: nightly
+        submodules: recursive
+        fetch-depth: 0 # Note: Needed to be able to pull the 'develop' branch as well for merging
+    - name: Checkout code along with submodules for the 'release' branch if the trigger event is 'scheduled'
+      uses: actions/checkout@v3
+      if: ${{ !contains(github.event.release.tag_name, 'nightly') }}
+      with:
+        ref: release
+        submodules: recursive
+        fetch-depth: 0 # Note: Needed to be able to pull the 'develop' branch as well for merging
+    - name: Tag the branch
+      run: |
+        TAG_NAME=$(node -p 'require("./package.json").version')
+        git tag -f $TAG_NAME
+        git push origin --tags --no-verify
+        # Also tag the submodule so as to help identify which changes went into which nightly release
+        # TODO: Not working due to cross-repo access issues by the github-action bot
+        # git -C recipes tag -f $TAG_NAME
+        # git -C recipes push origin --tags --no-verify


### PR DESCRIPTION
…publishing process

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Moved the tagging of the repo to a post-publish event.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
Currently, the git repo gets tagged when the nightly build runs. From the instant that the code gets tagged till the time that the release is published, there's a chance that anyone running the in-app update can face a broken ui.

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
