### PR TITLE
chore: correctly export/import ui elements

### DIFF
--- a/src/components/AppUpdateInfoBar.tsx
+++ b/src/components/AppUpdateInfoBar.tsx
@@ -4,7 +4,7 @@ import { mdiInformation } from '@mdi/js';
 import InfoBar from './ui/InfoBar';
 import { GITHUB_FERDIUM_URL } from '../config';
 import { openExternalUrl } from '../helpers/url-helpers';
-import { Icon } from './ui/icon';
+import Icon from './ui/icon';
 
 const messages = defineMessages({
   updateAvailable: {

--- a/src/components/auth/AuthLayout.js
+++ b/src/components/auth/AuthLayout.js
@@ -19,7 +19,7 @@ import globalMessages from '../../i18n/globalMessages';
 import { isWindows } from '../../environment';
 import AppUpdateInfoBar from '../AppUpdateInfoBar';
 import { GITHUB_FERDIUM_URL } from '../../config';
-import { Icon } from '../ui/icon';
+import Icon from '../ui/icon';
 
 class AuthLayout extends Component {
   static propTypes = {

--- a/src/components/auth/SetupAssistant.js
+++ b/src/components/auth/SetupAssistant.js
@@ -5,11 +5,11 @@ import { defineMessages, injectIntl } from 'react-intl';
 import injectSheet from 'react-jss';
 import classnames from 'classnames';
 
-import { Input } from '../ui/input/index';
+import Input from '../ui/input/index';
 import Button from '../ui/button';
-import { Badge } from '../ui/badge';
+import Badge from '../ui/badge';
 import Modal from '../ui/Modal';
-import * as Infobox from '../ui/Infobox';
+import Infobox from '../ui/Infobox';
 import Appear from '../ui/effects/Appear';
 import globalMessages from '../../i18n/globalMessages';
 

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -20,7 +20,7 @@ import WorkspaceSwitchingIndicator from '../../features/workspaces/components/Wo
 import { workspaceStore } from '../../features/workspaces';
 import AppUpdateInfoBar from '../AppUpdateInfoBar';
 import Todos from '../../features/todos/containers/TodosScreen';
-import { Icon } from '../ui/icon';
+import Icon from '../ui/icon';
 
 import LockedScreen from '../../containers/auth/LockedScreen';
 

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -32,7 +32,7 @@ import { todoActions } from '../../features/todos/actions';
 import AppStore from '../../stores/AppStore';
 import SettingsStore from '../../stores/SettingsStore';
 import globalMessages from '../../i18n/globalMessages';
-import { Icon } from '../ui/icon';
+import Icon from '../ui/icon';
 
 const messages = defineMessages({
   addNewService: {

--- a/src/components/services/content/ConnectionLostBanner.js
+++ b/src/components/services/content/ConnectionLostBanner.js
@@ -6,7 +6,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { mdiAlert } from '@mdi/js';
 import { LIVE_API_FERDIUM_WEBSITE } from '../../../config';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 
 const messages = defineMessages({
   text: {

--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -14,7 +14,7 @@ import ServiceModel from '../../../models/Service';
 import { cmdOrCtrlShortcutKey, shiftKey, altKey } from '../../../environment';
 import globalMessages from '../../../i18n/globalMessages';
 import SettingsStore from '../../../stores/SettingsStore';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 
 const IS_SERVICE_DEBUGGING_ENABLED = (
   localStorage.getItem('debug') || ''

--- a/src/components/settings/SettingsLayout.js
+++ b/src/components/settings/SettingsLayout.js
@@ -7,7 +7,7 @@ import { mdiClose } from '@mdi/js';
 import ErrorBoundary from '../util/ErrorBoundary';
 import { oneOrManyChildElements } from '../../prop-types';
 import Appear from '../ui/effects/Appear';
-import { Icon } from '../ui/icon';
+import Icon from '../ui/icon';
 
 const messages = defineMessages({
   closeSettings: {

--- a/src/components/settings/recipes/RecipesDashboard.js
+++ b/src/components/settings/recipes/RecipesDashboard.js
@@ -8,8 +8,8 @@ import injectSheet from 'react-jss';
 
 import { mdiOpenInNew } from '@mdi/js';
 import Button from '../../ui/button';
-import { Input } from '../../ui/input/index';
-import { H3, H2, H1 } from '../../ui/headline';
+import Input from '../../ui/input/index';
+import { H1, H2, H3 } from '../../ui/headline';
 import SearchInput from '../../ui/SearchInput';
 import Infobox from '../../ui/Infobox';
 import RecipeItem from './RecipeItem';
@@ -17,7 +17,7 @@ import Loader from '../../ui/Loader';
 import Appear from '../../ui/effects/Appear';
 import { FERDIUM_SERVICE_REQUEST } from '../../../config';
 import RecipePreview from '../../../models/RecipePreview';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 
 const messages = defineMessages({
   headline: {

--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -10,7 +10,7 @@ import Form from '../../../lib/Form';
 import Recipe from '../../../models/Recipe';
 import Service from '../../../models/Service';
 import Tabs from '../../ui/Tabs/Tabs';
-import { TabItem } from '../../ui/Tabs/TabItem';
+import TabItem from '../../ui/Tabs/TabItem';
 import Input from '../../ui/Input';
 import Toggle from '../../ui/Toggle';
 import Slider from '../../ui/Slider';
@@ -20,7 +20,7 @@ import Select from '../../ui/Select';
 
 import { isMac } from '../../../environment';
 import globalMessages from '../../../i18n/globalMessages';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 import { H3 } from '../../ui/headline';
 
 const messages = defineMessages({

--- a/src/components/settings/services/ServiceItem.js
+++ b/src/components/settings/services/ServiceItem.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 
 import { mdiBellOff, mdiMessageBulletedOff, mdiPower } from '@mdi/js';
 import ServiceModel from '../../../models/Service';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 
 const messages = defineMessages({
   tooltipIsDisabled: {

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -31,7 +31,7 @@ import {
 } from '../../../environment-remote';
 import { openPath } from '../../../helpers/url-helpers';
 import globalMessages from '../../../i18n/globalMessages';
-import { Icon } from '../../ui/icon';
+import Icon from '../../ui/icon';
 import Slider from '../../ui/Slider';
 
 const debug = require('../../../preload-safe-debug')('Ferdium:EditSettingsForm');

--- a/src/components/settings/user/EditUserForm.js
+++ b/src/components/settings/user/EditUserForm.js
@@ -4,7 +4,7 @@ import { observer, PropTypes as MobxPropTypes } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Link } from 'react-router';
 
-import { Input } from '../../ui/input/index';
+import Input from '../../ui/input/index';
 import Form from '../../../lib/Form';
 import Button from '../../ui/button';
 import Radio from '../../ui/Radio';

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import Dropzone from 'react-dropzone';
 import { mdiDelete, mdiFileImage } from '@mdi/js';
 import { isWindows } from '../../environment';
-import { Icon } from './icon';
+import Icon from './icon';
 
 type Props = {
   field: typeof Field;

--- a/src/components/ui/InfoBar.js
+++ b/src/components/ui/InfoBar.js
@@ -7,7 +7,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { mdiClose } from '@mdi/js';
 import Appear from './effects/Appear';
-import { Icon } from './icon';
+import Icon from './icon';
 
 const messages = defineMessages({
   hide: {

--- a/src/components/ui/Infobox.js
+++ b/src/components/ui/Infobox.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import Loader from 'react-loader';
 import { defineMessages, injectIntl } from 'react-intl';
 import { mdiAlert, mdiCheckboxMarkedCircleOutline, mdiClose } from '@mdi/js';
-import { Icon } from '../ui/icon';
+import Icon from '../ui/icon';
 
 const icons = {
   'checkbox-marked-circle-outline': mdiCheckboxMarkedCircleOutline,

--- a/src/components/ui/Input.js
+++ b/src/components/ui/Input.js
@@ -7,7 +7,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { mdiEye, mdiEyeOff } from '@mdi/js';
 import { scorePassword as scorePasswordFunc } from '../../helpers/password-helpers';
-import { Icon } from './icon';
+import Icon from './icon';
 
 const messages = defineMessages({
   passwordToggle: {

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import injectCSS from 'react-jss';
 import { mdiClose } from '@mdi/js';
 
-import { Icon } from '../icon';
+import Icon from '../icon';
 import styles from './styles';
 
 type Props = {

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 import { mdiCloseCircleOutline, mdiMagnify } from '@mdi/js';
-import { Icon } from './icon';
+import Icon from './icon';
 
 type Props = {
   value: string;

--- a/src/components/ui/Tabs/TabItem.tsx
+++ b/src/components/ui/Tabs/TabItem.tsx
@@ -1,1 +1,1 @@
-export const TabItem = ({ children }) => <>{children}</>;
+export default ({ children }) => <>{children}</>;

--- a/src/components/ui/badge/ProBadge.tsx
+++ b/src/components/ui/badge/ProBadge.tsx
@@ -4,8 +4,8 @@ import { Component } from 'react';
 import injectStyle, { WithStylesProps } from 'react-jss';
 
 import { Theme } from '../../../themes';
-import { Icon } from '../icon';
-import { Badge } from './index';
+import Icon from '../icon';
+import Badge from './index';
 
 interface IProps extends WithStylesProps<typeof styles> {
   badgeClasses?: string;

--- a/src/components/ui/badge/index.tsx
+++ b/src/components/ui/badge/index.tsx
@@ -67,4 +67,4 @@ class BadgeComponent extends Component<IProps> {
   }
 }
 
-export const Badge = injectStyle(styles, { injectTheme: true })(BadgeComponent);
+export default injectStyle(styles, { injectTheme: true })(BadgeComponent);

--- a/src/components/ui/error/index.tsx
+++ b/src/components/ui/error/index.tsx
@@ -17,4 +17,4 @@ class ErrorComponent extends Component<IProps> {
   }
 }
 
-export const Error = injectSheet(styles, { injectTheme: true })(ErrorComponent);
+export default injectSheet(styles, { injectTheme: true })(ErrorComponent);

--- a/src/components/ui/icon/index.tsx
+++ b/src/components/ui/icon/index.tsx
@@ -42,4 +42,4 @@ class IconComponent extends Component<IProps> {
   }
 }
 
-export const Icon = injectStyle(styles, { injectTheme: true })(IconComponent);
+export default injectStyle(styles, { injectTheme: true })(IconComponent);

--- a/src/components/ui/infobox/index.tsx
+++ b/src/components/ui/infobox/index.tsx
@@ -4,7 +4,7 @@ import { Component, ReactNode } from 'react';
 import injectStyle, { WithStylesProps } from 'react-jss';
 
 import { Theme } from '../../../themes';
-import { Icon } from '../icon';
+import Icon from '../icon';
 
 interface IProps extends WithStylesProps<typeof styles> {
   icon?: string;
@@ -199,6 +199,6 @@ class InfoboxComponent extends Component<IProps, IState> {
   }
 }
 
-export const Infobox = injectStyle(styles, { injectTheme: true })(
+export default injectStyle(styles, { injectTheme: true })(
   InfoboxComponent,
 );

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -6,9 +6,9 @@ import injectSheet, { WithStylesProps } from 'react-jss';
 
 import { IFormField } from '../typings/generic';
 
-import { Error } from '../error';
-import { Label } from '../label';
-import { Wrapper } from '../wrapper';
+import Error from '../error';
+import Label from '../label';
+import Wrapper from '../wrapper';
 import { scorePasswordFunc } from './scorePassword';
 
 import styles from './styles';
@@ -205,4 +205,4 @@ class InputComponent extends Component<IProps, IState> {
   }
 }
 
-export const Input = injectSheet(styles, { injectTheme: true })(InputComponent);
+export default injectSheet(styles, { injectTheme: true })(InputComponent);

--- a/src/components/ui/label/index.tsx
+++ b/src/components/ui/label/index.tsx
@@ -50,4 +50,4 @@ class LabelComponent extends Component<ILabel> {
   }
 }
 
-export const Label = injectSheet(styles, { injectTheme: true })(LabelComponent);
+export default injectSheet(styles, { injectTheme: true })(LabelComponent);

--- a/src/components/ui/loader/index.tsx
+++ b/src/components/ui/loader/index.tsx
@@ -41,6 +41,6 @@ class LoaderComponent extends Component<IProps> {
   }
 }
 
-export const Loader = injectStyle(styles, { injectTheme: true })(
+export default injectStyle(styles, { injectTheme: true })(
   LoaderComponent,
 );

--- a/src/components/ui/select/index.tsx
+++ b/src/components/ui/select/index.tsx
@@ -11,9 +11,9 @@ import injectStyle, { WithStylesProps } from 'react-jss';
 import { Theme } from '../../../themes';
 import { IFormField } from '../typings/generic';
 
-import { Error } from '../error';
-import { Label } from '../label';
-import { Wrapper } from '../wrapper';
+import Error from '../error';
+import Label from '../label';
+import Wrapper from '../wrapper';
 
 interface IOptions {
   [index: string]: string;

--- a/src/components/ui/textarea/index.tsx
+++ b/src/components/ui/textarea/index.tsx
@@ -4,9 +4,9 @@ import injectSheet, { WithStylesProps } from 'react-jss';
 
 import { IFormField } from '../typings/generic';
 
-import { Error } from '../error';
-import { Label } from '../label';
-import { Wrapper } from '../wrapper';
+import Error from '../error';
+import Label from '../label';
+import Wrapper from '../wrapper';
 
 import styles from './styles';
 

--- a/src/components/ui/toggle/index.tsx
+++ b/src/components/ui/toggle/index.tsx
@@ -6,9 +6,9 @@ import injectStyle, { WithStylesProps } from 'react-jss';
 import { Theme } from '../../../themes';
 import { IFormField } from '../typings/generic';
 
-import { Error } from '../error';
-import { Label } from '../label';
-import { Wrapper } from '../wrapper';
+import Error from '../error';
+import Label from '../label';
+import Wrapper from '../wrapper';
 
 interface IProps
   extends InputHTMLAttributes<HTMLInputElement>,
@@ -122,6 +122,6 @@ class ToggleComponent extends Component<IProps> {
   }
 }
 
-export const Toggle = injectStyle(styles, { injectTheme: true })(
+export default injectStyle(styles, { injectTheme: true })(
   ToggleComponent,
 );

--- a/src/components/ui/wrapper/index.tsx
+++ b/src/components/ui/wrapper/index.tsx
@@ -33,6 +33,6 @@ class WrapperComponent extends Component<IProps> {
   }
 }
 
-export const Wrapper = injectStyle(styles, { injectTheme: true })(
+export default injectStyle(styles, { injectTheme: true })(
   WrapperComponent,
 );

--- a/src/features/publishDebugInfo/Component.js
+++ b/src/features/publishDebugInfo/Component.js
@@ -8,7 +8,7 @@ import { state as ModalState } from './store';
 import { H1 } from '../../components/ui/headline';
 import { sendAuthRequest } from '../../api/utils/auth';
 import Button from '../../components/ui/button';
-import { Input } from '../../components/ui/input/index';
+import Input from '../../components/ui/input/index';
 import Modal from '../../components/ui/Modal';
 import { DEBUG_API } from '../../config';
 import AppStore from '../../stores/AppStore';

--- a/src/features/quickSwitch/Component.js
+++ b/src/features/quickSwitch/Component.js
@@ -7,7 +7,7 @@ import injectSheet from 'react-jss';
 import { defineMessages, injectIntl } from 'react-intl';
 import { compact, invoke } from 'lodash';
 
-import { Input } from '../../components/ui/input/index';
+import Input from '../../components/ui/input/index';
 import { H1 } from '../../components/ui/headline';
 import Modal from '../../components/ui/Modal';
 import { state as ModalState } from './store';

--- a/src/features/webControls/components/WebControls.js
+++ b/src/features/webControls/components/WebControls.js
@@ -12,7 +12,7 @@ import {
   mdiEarth,
 } from '@mdi/js';
 
-import { Icon } from '../../../components/ui/icon';
+import Icon from '../../../components/ui/icon';
 
 const messages = defineMessages({
   goHome: {

--- a/src/features/workspaces/components/CreateWorkspaceForm.js
+++ b/src/features/workspaces/components/CreateWorkspaceForm.js
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
 import injectSheet from 'react-jss';
 
-import { Input } from '../../../components/ui/input/index';
+import Input from '../../../components/ui/input/index';
 import Button from '../../../components/ui/button';
 import Form from '../../../lib/Form';
 import { required } from '../../../helpers/validation-helpers';

--- a/src/features/workspaces/components/EditWorkspaceForm.js
+++ b/src/features/workspaces/components/EditWorkspaceForm.js
@@ -5,8 +5,8 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { Link } from 'react-router';
 import injectSheet from 'react-jss';
 
-import { Infobox } from '../../../components/ui/infobox/index';
-import { Input } from '../../../components/ui/input/index';
+import Infobox from '../../../components/ui/infobox/index';
+import Input from '../../../components/ui/input/index';
 import Button from '../../../components/ui/button';
 import Workspace from '../models/Workspace';
 import Service from '../../../models/Service';

--- a/src/features/workspaces/components/WorkspaceDrawer.js
+++ b/src/features/workspaces/components/WorkspaceDrawer.js
@@ -8,7 +8,7 @@ import ReactTooltip from 'react-tooltip';
 import { mdiPlusBox, mdiCog } from '@mdi/js';
 
 import { H1 } from '../../../components/ui/headline';
-import { Icon } from '../../../components/ui/icon';
+import Icon from '../../../components/ui/icon';
 import WorkspaceDrawerItem from './WorkspaceDrawerItem';
 import { workspaceActions } from '../actions';
 import { workspaceStore } from '../index';

--- a/src/features/workspaces/components/WorkspaceServiceListItem.tsx
+++ b/src/features/workspaces/components/WorkspaceServiceListItem.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import injectSheet from 'react-jss';
 import classnames from 'classnames';
 
-import { Toggle } from '../../../components/ui/toggle/index';
+import Toggle from '../../../components/ui/toggle/index';
 import ServiceIcon from '../../../components/ui/ServiceIcon';
 
 const styles = theme => ({

--- a/src/features/workspaces/components/WorkspaceSwitchingIndicator.js
+++ b/src/features/workspaces/components/WorkspaceSwitchingIndicator.js
@@ -5,7 +5,7 @@ import injectSheet from 'react-jss';
 import classnames from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 
-import { Loader } from '../../../components/ui/loader/index';
+import Loader from '../../../components/ui/loader/index';
 import { workspaceStore } from '../index';
 
 const messages = defineMessages({

--- a/src/features/workspaces/components/WorkspacesDashboard.js
+++ b/src/features/workspaces/components/WorkspacesDashboard.js
@@ -5,7 +5,7 @@ import { observer, PropTypes as MobxPropTypes, inject } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
 import injectSheet from 'react-jss';
 
-import { Infobox } from '../../../components/ui/infobox/index';
+import Infobox from '../../../components/ui/infobox/index';
 import Loader from '../../../components/ui/Loader';
 import WorkspaceItem from './WorkspaceItem';
 import CreateWorkspaceForm from './CreateWorkspaceForm';


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Pure technical change to update all exports/imports of UI elements, these are not an issue right now but are a cleanup to support the upgrade to latest mobx/react-router.

Solves issues in the editor (and browser after dependency upgrade) like: 
![image](https://user-images.githubusercontent.com/2735602/176838197-7deb7d3e-09ff-427b-8bcc-fe094d5997ee.png)

Chosen to use all default exports where preferable, except the heading component which exports multiple objects (h1,h2,h3 etc)

This will reduce the size of PR #406.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
