### PR TITLE
Disable symlinks to build_id for rpm

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,9 @@ appImage:
 deb:
   artifactName: "${productName}-${os}-${version}-${arch}.${ext}"
 
-
+rpm:
+  # Prevent creation of symlinks in /usr/lib/.build_id to avoid conflicts with other electron-based app having the symlink to chrome-sandbox
+  fpm: ["--rpm-rpmbuild-define=_build_id_links none"]
 
 # This is the notarization process which allows the app to be opened after download with the minimal warning.
 afterSign: ./build-helpers/notarize.js


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Add a parameter to `electron-builder` when creating the `rpm` asset to disable the creation of symlinks in `/usr/lib/.build-id`.
Fix #416.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
When installing with rpm, the scripts accesses a symlink in `/usr/lib/.build-id` to `chrome-sandbox`. However, any electron app built the same way will intend to do the same, causing a conflict if these apps do not use the same version of electron. Disabling the creation of symlinks by `rpm-builder` will avoid this conflict. 

⚠️ A drawback of this choice is that it can potentially prevent a user to debug the app (only a supposition as my knowledge of rpm builds is fairly small). 

#### Screenshots
<!-- Remove the section if this does not apply. -->
With a package built on electron (`drawio-desktop`) installed from its rpm, I tried to install the current Ferdium release, which fails. After building with the additional parameter, installation goes smoothly.
![Capture d’écran 2022-07-04 à 03 11 12](https://user-images.githubusercontent.com/34252790/177070482-2c0f3f41-b295-48ac-b717-03bf5f9df8d7.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] I tested/previewed my changes locally building on personal fork

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
