### PR TITLE
Add file size info and error for import custom image on recipe

### DIFF
--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -406,7 +406,7 @@ class EditServiceForm extends Component {
                   field={form.$('customIcon')}
                   textDelete={intl.formatMessage(messages.iconDelete)}
                   textUpload={intl.formatMessage(messages.iconUpload)}
-                  maxSize={1_048_576}
+                  maxSize={2_097_152}
                   maxFiles={1}
                   textMaxFileSize={intl.formatMessage(messages.maxFileSize)}
                   textMaxFileSizeError={intl.formatMessage(

--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -141,6 +141,14 @@ const messages = defineMessages({
     id: 'settings.service.reloadRequired',
     defaultMessage: 'Changes require reload of the service',
   },
+  maxFileSize: {
+    id: 'settings.service.form.maxFileSize',
+    defaultMessage: 'Maximum filesize:',
+  },
+  maxFileSizeError: {
+    id: 'settings.service.form.maxFileSizeError',
+    defaultMessage: 'The file you are trying to submit is too large.',
+  },
 });
 
 class EditServiceForm extends Component {
@@ -398,6 +406,12 @@ class EditServiceForm extends Component {
                   field={form.$('customIcon')}
                   textDelete={intl.formatMessage(messages.iconDelete)}
                   textUpload={intl.formatMessage(messages.iconUpload)}
+                  maxSize={1_048_576}
+                  maxFiles={1}
+                  textMaxFileSize={intl.formatMessage(messages.maxFileSize)}
+                  textMaxFileSizeError={intl.formatMessage(
+                    messages.maxFileSizeError,
+                  )}
                 />
               </div>
             </div>

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -4,6 +4,7 @@ import { Field } from 'mobx-react-form';
 import classnames from 'classnames';
 import Dropzone from 'react-dropzone';
 import { mdiDelete, mdiFileImage } from '@mdi/js';
+import prettyBytes from 'pretty-bytes';
 import { isWindows } from '../../environment';
 import Icon from './icon';
 
@@ -13,20 +14,33 @@ type Props = {
   multiple: boolean;
   textDelete: string;
   textUpload: string;
+  textMaxFileSize: string;
+  textMaxFileSizeError: string;
+  maxSize?: number;
+  maxFiles?: number;
+  messages: any;
 };
 
 // Should this file be converted into the coding style similar to './toggle/index.tsx'?
 class ImageUpload extends Component<Props> {
   static defaultProps = {
     multiple: false,
+    maxSize: Number.POSITIVE_INFINITY,
+    maxFiles: 0,
   };
 
   state = {
     path: null,
+    errorState: false,
   };
 
-  onDrop(acceptedFiles) {
+  errorMessage = {
+    message: '',
+  };
+
+  onDropAccepted(acceptedFiles) {
     const { field } = this.props;
+    this.setState({ errorState: false });
 
     for (const file of acceptedFiles) {
       const imgPath = isWindows ? file.path.replace(/\\/g, '/') : file.path;
@@ -40,13 +54,42 @@ class ImageUpload extends Component<Props> {
     field.set('');
   }
 
+  onDropRejected(rejectedFiles) {
+    for (const file of rejectedFiles) {
+      for (const error of file.errors) {
+        if (error.code === 'file-too-large') {
+          this.setState({ errorState: true });
+          this.setState(
+            (this.errorMessage = {
+              message: this.props.textMaxFileSizeError,
+            }),
+          );
+        }
+      }
+    }
+  }
+
   render() {
-    const { field, className, multiple, textDelete, textUpload } = this.props;
+    const {
+      field,
+      className,
+      multiple,
+      textDelete,
+      textUpload,
+      textMaxFileSize,
+      maxSize,
+      maxFiles,
+    } = this.props;
 
     const cssClasses = classnames({
       'image-upload__dropzone': true,
       [`${className}`]: className,
     });
+
+    const maxSizeParse =
+      maxSize === undefined || maxSize === Number.POSITIVE_INFINITY
+        ? 0
+        : maxSize;
 
     return (
       <div className="image-upload-wrapper">
@@ -83,9 +126,13 @@ class ImageUpload extends Component<Props> {
             </>
           ) : (
             <Dropzone
-              onDrop={this.onDrop.bind(this)}
+              onDropAccepted={this.onDropAccepted.bind(this)}
+              onDropRejected={this.onDropRejected.bind(this)}
               multiple={multiple}
               accept="image/jpeg, image/png, image/svg+xml"
+              minSize={0}
+              maxSize={maxSize}
+              maxFiles={maxFiles}
             >
               {({ getRootProps, getInputProps }) => (
                 <div {...getRootProps()} className={cssClasses}>
@@ -97,6 +144,17 @@ class ImageUpload extends Component<Props> {
             </Dropzone>
           )}
         </div>
+        {maxSizeParse !== 0 && (
+          <span className="image-upload-wrapper__file-size">
+            {textMaxFileSize}{' '}
+            {prettyBytes(maxSizeParse, { maximumFractionDigits: 1 })}
+          </span>
+        )}
+        {this.state.errorState && (
+          <span className="image-upload-wrapper__file-size-error">
+            {this.errorMessage.message}
+          </span>
+        )}
       </div>
     );
   }

--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -54,7 +54,7 @@ class ImageUpload extends Component<Props> {
     field.set('');
   }
 
-  onDropRejected(rejectedFiles) {
+  onDropRejected(rejectedFiles): void {
     for (const file of rejectedFiles) {
       for (const error of file.errors) {
         if (error.code === 'file-too-large') {
@@ -86,7 +86,7 @@ class ImageUpload extends Component<Props> {
       [`${className}`]: className,
     });
 
-    const maxSizeParse =
+    const maxSizeParse: number =
       maxSize === undefined || maxSize === Number.POSITIVE_INFINITY
         ? 0
         : maxSize;

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -371,6 +371,8 @@
   "settings.service.form.useHostedService": "Use the hosted {name} service.",
   "settings.service.form.yourServices": "Your services",
   "settings.service.reloadRequired": "Changes require reload of the service",
+  "settings.service.form.maxFileSize": "Maximum filesize:",
+  "settings.service.form.maxFileSizeError": "The file you are trying to submit is too large.",
   "settings.services.deletedInfo": "Service has been deleted",
   "settings.services.discoverServices": "Discover services",
   "settings.services.headline": "Your services",

--- a/src/styles/image-upload.scss
+++ b/src/styles/image-upload.scss
@@ -112,3 +112,17 @@
   color: $theme-gray-light;
   font-size: 40px;
 }
+
+.image-upload-wrapper__file-size {
+  display: flex;
+  color: $theme-gray-light;
+  font-size: 10px;
+  margin-top: 3px;
+}
+
+.image-upload-wrapper__file-size-error {
+  display: flex;
+  color: $theme-brand-danger;
+  font-size: 12px;
+  margin-top: 10px;
+}


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This adds the ability of having the file size info and error on the import image component

#### Motivation and Context
When you try to import a file larger than 1 MB, ~~an error of 413 (nginx) happens on the server side (if you're using Ferdium Server)~~ (changed to 2MB on nginx side). This ensures that the user imports a smaller filer size.
If you're using Ferdium without an account this value is ALSO 2 MB ~~altough this PR only accounts for the above situation (maybe we can also change it on Ferdium Server nginx side to ensure the same value)~~

#### Screenshots
| Before <br /> ![image](https://user-images.githubusercontent.com/37463445/177600897-c039a9dd-04b6-407d-9d37-5c650d4a90c4.png) | After <br /> ![image](https://user-images.githubusercontent.com/37463445/177600783-17dfb186-83d8-481d-ae0a-f8f817258a62.png) |
|-- |-- |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Add file size info and error for import custom image on recipe