### PR TITLE
Workaround for 71c5237 (#406)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,12 @@ const createWindow = () => {
   if (isWindows) {
     onDidLoad((window: BrowserWindow) => {
       const url = process.argv.slice(1);
-      if (url) {
+      if (
+        url &&
+        // The next line is a workaround after this 71c5237 [chore: Mobx & React-Router upgrade (#406)].
+        // For some reason, the app won't start until because it's trying to route to './build'.
+        url.toString() !== './build'
+      ) {
         handleDeepLink(window, url.toString());
       }
     });

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -638,7 +638,7 @@ class FranzMenu {
   }
 
   get template() {
-    return this.currentTemplate.toJS();
+    return JSON.parse(JSON.stringify(this.currentTemplate));
   }
 
   _build() {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This is a workaround for 71c5237 (#406).

#### Motivation and Context
After #406 trying to run Ferdium on Windows fails on startup.
- As far as me and @cino found, this is due to trying to navigate from deep link to route to `./build` (on `onDidLoad`) which is a nonexistent path. This behavior was also there before, but seems it didn't have an impact so far.
- Also the function `.toJS()` seems not to exist on `currentTemplate` so, `JSON.parse(JSON.stringify(this.currentTemplate))` workaround is needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
