### PR TITLE
Fix Menu bar on Windows not being clickable

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -10,6 +10,7 @@ import {
 import { autorun, makeObservable, observable } from 'mobx';
 import { defineMessages } from 'react-intl';
 import osName from 'os-name';
+import { fromJS } from "immutable";
 import {
   CUSTOM_WEBSITE_RECIPE_ID,
   GITHUB_FERDIUM_URL,
@@ -638,7 +639,7 @@ class FranzMenu {
   }
 
   get template() {
-    return JSON.parse(JSON.stringify(this.currentTemplate));
+    return fromJS(this.currentTemplate).toJS();
   }
 
   _build() {
@@ -892,7 +893,10 @@ class FranzMenu {
             title: 'Ferdium',
             message: 'Ferdium',
             detail: aboutAppDetails,
-            buttons: [intl.formatMessage(menuItems.ok), intl.formatMessage(menuItems.copyToClipboard)],
+            buttons: [
+              intl.formatMessage(menuItems.ok),
+              intl.formatMessage(menuItems.copyToClipboard),
+            ],
           })
           .then(result => {
             if (result.response === 1) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Fix Menu bar on Windows not being clickable

#### Motivation and Context
This changes the hack we made on `Menu.js` after the update of the `mobx` dependencies (which prevented the app to startup on windows). It seems like the previous implementation broke the Menu Bar on Windows, making items unclickable (throwing a type error saying `a.click` was not a function). This PR now solves this issue.
This can maybe help on https://github.com/ferdium/ferdium-app/issues/460 being solved. Will monitor and see if it solves it on the next nightly update.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Fix Menu bar on Windows not being clickable