### PR TITLE
Welcome screen and SetupAssistant changes

### DIFF
--- a/src/components/auth/AuthLayout.jsx
+++ b/src/components/auth/AuthLayout.jsx
@@ -36,9 +36,13 @@ class AuthLayout extends Component {
     appUpdateIsDownloaded: PropTypes.bool.isRequired,
   };
 
-  state = {
-    shouldShowAppUpdateInfoBar: true,
-  };
+  constructor() {
+    super();
+
+    this.state = {
+      shouldShowAppUpdateInfoBar: true,
+    };
+  }
 
   render() {
     const {
@@ -91,7 +95,9 @@ class AuthLayout extends Component {
               onClick={retryHealthCheck}
             >
               <Icon icon={mdiFlash} />
-              {intl.formatMessage(globalMessages.APIUnhealthy, { serverNameParse })}
+              {intl.formatMessage(globalMessages.APIUnhealthy, {
+                serverNameParse,
+              })}
             </InfoBar>
           )}
           <div className="auth__layout">

--- a/src/components/auth/ChangeServer.jsx
+++ b/src/components/auth/ChangeServer.jsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { observer } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
+import { mdiArrowLeftCircle } from '@mdi/js';
 import Form from '../../lib/Form';
 import Input from '../ui/Input';
 import Select from '../ui/Select';
@@ -12,6 +13,7 @@ import { url, required } from '../../helpers/validation-helpers';
 import { LIVE_FERDIUM_API, LIVE_FRANZ_API } from '../../config';
 import globalMessages from '../../i18n/globalMessages';
 import { H1 } from '../ui/headline';
+import Icon from '../ui/icon';
 
 const messages = defineMessages({
   headline: {
@@ -46,35 +48,36 @@ class ChangeServer extends Component {
 
   franzServer = LIVE_FRANZ_API;
 
-  defaultServers = [ this.ferdiumServer, this.franzServer ];
+  defaultServers = [this.ferdiumServer, this.franzServer];
 
   form = (() => {
     const { intl } = this.props;
-    return new Form({
-      fields: {
-        server: {
-          label: intl.formatMessage(messages.label),
-          value: this.props.server,
-          options: [
-            { value: this.ferdiumServer, label: 'Ferdium (Default)' },
-            { value: this.franzServer, label: 'Franz' },
-            {
-              value: this.defaultServers.includes(this.props.server)
-                ? ''
-                : this.props.server,
-              label: 'Custom',
-            },
-          ],
-        },
-        customServer: {
-          label: intl.formatMessage(messages.customServerLabel),
-          value: '',
-          validators: [url, required],
+    return new Form(
+      {
+        fields: {
+          server: {
+            label: intl.formatMessage(messages.label),
+            value: this.props.server,
+            options: [
+              { value: this.ferdiumServer, label: 'Ferdium (Default)' },
+              { value: this.franzServer, label: 'Franz' },
+              {
+                value: this.defaultServers.includes(this.props.server)
+                  ? ''
+                  : this.props.server,
+                label: 'Custom',
+              },
+            ],
+          },
+          customServer: {
+            label: intl.formatMessage(messages.customServerLabel),
+            value: '',
+            validators: [url, required],
+          },
         },
       },
-    },
-    intl,
-  );
+      intl,
+    );
   })();
 
   componentDidMount() {
@@ -109,9 +112,11 @@ class ChangeServer extends Component {
     return (
       <div className="auth__container">
         <form className="franz-form auth__form" onSubmit={e => this.submit(e)}>
-          <Link to='/auth/welcome'><img src="./assets/images/logo.svg" className="auth__logo" alt="" /></Link>
+          <Link to="/auth/welcome">
+            <img src="./assets/images/logo.svg" className="auth__logo" alt="" />
+          </Link>
           <H1>{intl.formatMessage(messages.headline)}</H1>
-          {(form.$('server').value === this.franzServer) && (
+          {form.$('server').value === this.franzServer && (
             <Infobox type="warning">
               {intl.formatMessage(messages.warning)}
             </Infobox>
@@ -121,8 +126,10 @@ class ChangeServer extends Component {
             <Input
               placeholder="Custom Server"
               onChange={e => {
-                this.form.$('customServer').value = this.form.$('customServer').value.replace(/\/$/, "");
-                this.submit(e)
+                this.form.$('customServer').value = this.form
+                  .$('customServer')
+                  .value.replace(/\/$/, '');
+                this.submit(e);
               }}
               field={form.$('customServer')}
             />
@@ -133,6 +140,11 @@ class ChangeServer extends Component {
             label={intl.formatMessage(globalMessages.submit)}
           />
         </form>
+        <div className="auth__help">
+          <Link to="/auth/welcome">
+            <Icon icon={mdiArrowLeftCircle} size={1.5} />
+          </Link>
+        </div>
       </div>
     );
   }

--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { observer, inject } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
 
+import { mdiArrowLeftCircle } from '@mdi/js';
+import Icon from '../ui/icon';
 import { LIVE_FRANZ_API } from '../../config';
 import { API_VERSION } from '../../environment-remote';
 import { serverBase } from '../../api/apiBase'; // TODO: Remove this line after fixing password recovery in-app
@@ -80,23 +82,25 @@ class Login extends Component {
 
   form = (() => {
     const { intl } = this.props;
-    return new Form({
-      fields: {
-        email: {
-          label: intl.formatMessage(messages.emailLabel),
-          value: '',
-          validators: [required, email],
-        },
-        password: {
-          label: intl.formatMessage(messages.passwordLabel),
-          value: '',
-          validators: [required],
-          type: 'password',
+    return new Form(
+      {
+        fields: {
+          email: {
+            label: intl.formatMessage(messages.emailLabel),
+            value: '',
+            validators: [required, email],
+          },
+          password: {
+            label: intl.formatMessage(messages.passwordLabel),
+            value: '',
+            validators: [required],
+            type: 'password',
+          },
         },
       },
-    },
-    intl,
-  )})();
+      intl,
+    );
+  })();
 
   submit(e) {
     e.preventDefault();
@@ -123,7 +127,9 @@ class Login extends Component {
     return (
       <div className="auth__container">
         <form className="franz-form auth__form" onSubmit={e => this.submit(e)}>
-          <Link to='/auth/welcome'><img src="./assets/images/logo.svg" className="auth__logo" alt="" /></Link>
+          <Link to="/auth/welcome">
+            <img src="./assets/images/logo.svg" className="auth__logo" alt="" />
+          </Link>
           <H1>{intl.formatMessage(messages.headline)}</H1>
           {isTokenExpired && (
             <p className="error-message center">
@@ -185,15 +191,15 @@ class Login extends Component {
           <Link
             // to={passwordRoute} // TODO: Uncomment this line after fixing password recovery in-app
             to={`${serverBase()}/user/forgot`} // TODO: Remove this line after fixing password recovery in-app
-            target='_blank' // TODO: Remove this line after fixing password recovery in-app
+            target="_blank" // TODO: Remove this line after fixing password recovery in-app
           >
             {intl.formatMessage(messages.passwordLink)}
           </Link>
         </div>
         <div className="auth__help">
-          <span>
-            {intl.formatMessage(messages.backToWelcome)}
-          </span>
+          <Link to="/auth/welcome">
+            <Icon icon={mdiArrowLeftCircle} size={1.5} />
+          </Link>
         </div>
       </div>
     );

--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -63,10 +63,6 @@ const messages = defineMessages({
     id: 'login.link.password',
     defaultMessage: 'Reset password',
   },
-  backToWelcome: {
-    id: 'login.backToWelcome',
-    defaultMessage: 'Click the Ferdium icon to go back to the Welcome screen',
-  },
 });
 
 class Login extends Component {

--- a/src/components/auth/SetupAssistant.jsx
+++ b/src/components/auth/SetupAssistant.jsx
@@ -32,6 +32,10 @@ const messages = defineMessages({
     id: 'setupAssistant.submit.label',
     defaultMessage: "Let's go",
   },
+  skipButtonLabel: {
+    id: 'setupAssistant.skip.label',
+    defaultMessage: 'Skip',
+  },
   inviteSuccessInfo: {
     id: 'invite.successInfo',
     defaultMessage: 'Invitations sent successfully',
@@ -145,21 +149,15 @@ class SetupAssistant extends Component {
     isInviteSuccessful: false,
   };
 
-  state = {
-    services: [
-      {
-        id: 'whatsapp',
-      },
-      {
-        id: 'messenger',
-      },
-      {
-        id: 'gmail',
-      },
-    ],
-    isSlackModalOpen: false,
-    slackWorkspace: '',
-  };
+  constructor() {
+    super();
+
+    this.state = {
+      services: [],
+      isSlackModalOpen: false,
+      slackWorkspace: '',
+    };
+  }
 
   slackWorkspaceHandler() {
     const { slackWorkspace = '', services } = this.state;
@@ -320,6 +318,13 @@ class SetupAssistant extends Component {
           onClick={() => onSubmit(this.state.services)}
           busy={isSettingUpServices}
           disabled={isSettingUpServices || addedServices.length === 0}
+        />
+        <Button
+          type="button"
+          className="auth__button auth__button--skip"
+          label={intl.formatMessage(messages.skipButtonLabel)}
+          onClick={() => onSubmit([])}
+          buttonType="secondary"
         />
       </div>
     );

--- a/src/components/auth/Signup.jsx
+++ b/src/components/auth/Signup.jsx
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types';
 import { observer, inject } from 'mobx-react';
 import { defineMessages, injectIntl } from 'react-intl';
 
+import { mdiArrowLeftCircle } from '@mdi/js';
 import Form from '../../lib/Form';
 import { required, email, minLength } from '../../helpers/validation-helpers';
 import Input from '../ui/Input';
 import Button from '../ui/button';
 import Link from '../ui/Link';
+import Icon from '../ui/icon';
 
 import { globalError as globalErrorPropType } from '../../prop-types';
 import { serverBase } from '../../api/apiBase';
@@ -75,33 +77,35 @@ class Signup extends Component {
 
   form = (() => {
     const { intl } = this.props;
-    return new Form({
-      fields: {
-        firstname: {
-          label: intl.formatMessage(messages.firstnameLabel),
-          value: '',
-          validators: [required],
-        },
-        lastname: {
-          label: intl.formatMessage(messages.lastnameLabel),
-          value: '',
-          validators: [required],
-        },
-        email: {
-          label: intl.formatMessage(messages.emailLabel),
-          value: '',
-          validators: [required, email],
-        },
-        password: {
-          label: intl.formatMessage(messages.passwordLabel),
-          value: '',
-          validators: [required, minLength(6)],
-          type: 'password',
+    return new Form(
+      {
+        fields: {
+          firstname: {
+            label: intl.formatMessage(messages.firstnameLabel),
+            value: '',
+            validators: [required],
+          },
+          lastname: {
+            label: intl.formatMessage(messages.lastnameLabel),
+            value: '',
+            validators: [required],
+          },
+          email: {
+            label: intl.formatMessage(messages.emailLabel),
+            value: '',
+            validators: [required, email],
+          },
+          password: {
+            label: intl.formatMessage(messages.passwordLabel),
+            value: '',
+            validators: [required, minLength(6)],
+            type: 'password',
+          },
         },
       },
-    },
-    intl,
-  )})();
+      intl,
+    );
+  })();
 
   submit(e) {
     e.preventDefault();
@@ -125,7 +129,13 @@ class Signup extends Component {
             className="franz-form auth__form"
             onSubmit={e => this.submit(e)}
           >
-            <Link to='/auth/welcome'><img src="./assets/images/logo.svg" className="auth__logo" alt="" /></Link>
+            <Link to="/auth/welcome">
+              <img
+                src="./assets/images/logo.svg"
+                className="auth__logo"
+                alt=""
+              />
+            </Link>
             <H1>{intl.formatMessage(messages.headline)}</H1>
             <div className="grid__row">
               <Input field={form.$('firstname')} focus />
@@ -180,6 +190,11 @@ class Signup extends Component {
           <div className="auth__links">
             <Link to={loginRoute}>
               {intl.formatMessage(messages.loginLink)}
+            </Link>
+          </div>
+          <div className="auth__help">
+            <Link to="/auth/welcome">
+              <Icon icon={mdiArrowLeftCircle} size={1.5} />
             </Link>
           </div>
         </div>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -64,7 +64,6 @@
   "locked.touchId": "Unlock with Touch ID",
   "locked.touchIdPrompt": "unlock via Touch ID",
   "locked.unlockWithPassword": "Unlock with Password",
-  "login.backToWelcome": "Click the Ferdium icon to go back to the Welcome screen",
   "login.changeServer": "Change here!",
   "login.changeServerMessage": "You are using {serverNameParse} Server, do you want to switch?",
   "login.customServerQuestion": "Using a custom Ferdium server?",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -427,6 +427,7 @@
   "setupAssistant.headline": "Let's get started",
   "setupAssistant.subheadline": "Choose from our most used services and get back on top of your messaging now.",
   "setupAssistant.submit.label": "Let's go",
+  "setupAssistant.skip.label": "Skip",
   "sidebar.addNewService": "Add new service",
   "sidebar.closeTodosDrawer": "Close Ferdium Todos",
   "sidebar.closeWorkspaceDrawer": "Close workspace drawer",

--- a/src/styles/auth.scss
+++ b/src/styles/auth.scss
@@ -86,7 +86,10 @@
   .auth__button {
     width: 100%;
 
-    &.auth__button--skip { margin: 10px auto 0; }
+    &.auth__button--skip {
+      margin: 10px auto 0;
+      width: 20%;
+    }
   }
 
   .touchid__button {

--- a/src/styles/auth.scss
+++ b/src/styles/auth.scss
@@ -49,6 +49,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: auto;
   }
 
   .auth__container {
@@ -127,7 +128,10 @@
   }
 
   .auth__help {
-    padding: 5% 2%;
+    display: flex;
+    padding-top: 2%;
+    padding-bottom: 2%;
+    justify-content: center;
   }
 
   .auth__adlk {
@@ -143,10 +147,8 @@
   .info-bar { position: absolute; }
 
   &__scroll-container {
-    max-height: 100vh;
-    padding: 80px 0;
-    overflow: auto;
     width: 100%;
+    height: fit-content;
   }
 
   .available-services { margin-bottom: 15px; }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
- Convert several files from `js` to `jsx` and fix lint
- Add back buttons on Login, Signup and Select Server pages - removed the previous text.
- Add ability to skip adding recipes after Signup (in SetupAssistant)
- Change default to no recipe selected when in SetupAssistant screen

#### Motivation and Context
There was a need of a cleaner UI with back elements and also a skip button on Setup Assistant screen.

#### Screenshots
**Welcome Screens**
| Login | Signup | Change Server |
|-- |-- |-- |
| ![image](https://user-images.githubusercontent.com/37463445/178544969-d18af82e-fba5-4da9-9cca-9bd4d82700a7.png)  | ![image](https://user-images.githubusercontent.com/37463445/178544630-42dd0962-f277-4aed-adc6-69cfa61d4b61.png) | ![image](https://user-images.githubusercontent.com/37463445/178544555-8b299365-477b-4d6b-a05d-30b98eae850b.png) |


**SetupAssistant Screen**
|![image](https://user-images.githubusercontent.com/37463445/178542786-3ee9ac84-f7b3-45b5-8c2b-3c0691c1d56c.png) |![image](https://user-images.githubusercontent.com/37463445/178542750-d4bfc6b1-b842-40b3-998e-5fa8ed3042ee.png) |
|-- |-- |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Welcome screen and SetupAssistant changes