### PR TITLE
chore: add mailto to email in md files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,4 +8,4 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Ferdium project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please open an issue or send an email to [our contact mail](hello@ferdium.org).
+If you are subject to or witness unacceptable behavior, or have any other concerns, please open an issue or send an email to [our contact mail](mailto:hello@ferdium.org).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,6 @@
 
 If you discover a minor vulnerability in Ferdium, please create a new issue on GitHub. Minor vulnerabilities are those, that do not leave the user at immediate danger, i.e. though remote code execution.
 
-If you discover a major vulnerability in Ferdium, please report it to us via E-Mail to `hello@ferdium.org`, prefixing your E-Mail subject with "[Security]". We will then come in contact with you as quickly as possible.
+If you discover a major vulnerability in Ferdium, please report it to us via E-Mail to [hello@ferdium.org](mailto:hello@ferdium.org?subject=[Security]%20), prefixing your E-Mail subject with "[Security]". We will then come in contact with you as quickly as possible.
 
 Please keep in mind that some vulnerabilities you find may not be due to Ferdium but instead due to ElectronJS or Chromium. In that case, please contact the owners of those projects instead.


### PR DESCRIPTION
Just added mailto: to the contact mails in security and code of conduct files.