### PR TITLE
Change module macos-notification-state to personal version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
         "npm": "8.13.2"
       },
       "optionalDependencies": {
-        "macos-notification-state": "2.0.1",
+        "macos-notification-state": "github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
         "node-mac-permissions": "2.2.1"
       }
     },
@@ -18086,9 +18086,10 @@
     },
     "node_modules/macos-notification-state": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.1.tgz",
-      "integrity": "sha512-FBaaSdqws2R6RCqIq9CqG+QnZicJu00vayc88LM+iII4P72b1bXeGdZpxgXeIeKzwdlP0xHsq1PfOImJH3GOAg==",
+      "resolved": "git+ssh://git@github.com/ferdium/macos-notification-state.git#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
+      "integrity": "sha512-Uzh3XrSNjxDx7Nf7zoREwRrKFhKagZ0Tij53lvVK8GObWUjGhfEdDeX0UR/IZDj0f7ac62GHAMJBIg+sruOjyA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0"
@@ -41399,9 +41400,9 @@
       }
     },
     "macos-notification-state": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.1.tgz",
-      "integrity": "sha512-FBaaSdqws2R6RCqIq9CqG+QnZicJu00vayc88LM+iII4P72b1bXeGdZpxgXeIeKzwdlP0xHsq1PfOImJH3GOAg==",
+      "version": "git+ssh://git@github.com/ferdium/macos-notification-state.git#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
+      "integrity": "sha512-Uzh3XrSNjxDx7Nf7zoREwRrKFhKagZ0Tij53lvVK8GObWUjGhfEdDeX0UR/IZDj0f7ac62GHAMJBIg+sruOjyA==",
+      "from": "macos-notification-state@github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "webpack-dev-server": "4.9.3"
   },
   "optionalDependencies": {
-    "macos-notification-state": "2.0.1",
+    "macos-notification-state": "github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
     "node-mac-permissions": "2.2.1"
   },
   "browserslist": [


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Use the forked version of the `macos-notification-state` module present in the org instead of the original one that is not working as expected.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
The module `macos-notification-state` does not build when installing, which is due to a misconfiguration in the parent project. This is fixed in a personal fork held on the org repository, which should now be used. Fixes #458.

Note that I haven't had the opportunity to verify that the installation is not problematic on windows/linux, but the automatic build should prevent any issue as this module is listed as an `optionalDependency`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally on macos

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
