### PR TITLE
Revert to older working version of 'macos-notification-state'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
         "npm": "8.14.0"
       },
       "optionalDependencies": {
-        "macos-notification-state": "github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
+        "macos-notification-state": "github:nbashkankov/macos-notification-state#fix-monterey-detect",
         "node-mac-permissions": "2.2.1"
       }
     },
@@ -18110,9 +18110,8 @@
       }
     },
     "node_modules/macos-notification-state": {
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/ferdium/macos-notification-state.git#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
-      "integrity": "sha512-Uzh3XrSNjxDx7Nf7zoREwRrKFhKagZ0Tij53lvVK8GObWUjGhfEdDeX0UR/IZDj0f7ac62GHAMJBIg+sruOjyA==",
+      "version": "1.3.6",
+      "resolved": "git+ssh://git@github.com/nbashkankov/macos-notification-state.git#c7959ecf657020a70b2720d1051fc5a3e4ecb118",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -41428,9 +41427,8 @@
       }
     },
     "macos-notification-state": {
-      "version": "git+ssh://git@github.com/ferdium/macos-notification-state.git#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
-      "integrity": "sha512-Uzh3XrSNjxDx7Nf7zoREwRrKFhKagZ0Tij53lvVK8GObWUjGhfEdDeX0UR/IZDj0f7ac62GHAMJBIg+sruOjyA==",
-      "from": "macos-notification-state@github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
+      "version": "git+ssh://git@github.com/nbashkankov/macos-notification-state.git#c7959ecf657020a70b2720d1051fc5a3e4ecb118",
+      "from": "macos-notification-state@github:nbashkankov/macos-notification-state#fix-monterey-detect",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "webpack-dev-server": "4.9.3"
   },
   "optionalDependencies": {
-    "macos-notification-state": "github:ferdium/macos-notification-state#0a168f5b1f94c1fd3c08272b8348884efdc83b83",
+    "macos-notification-state": "github:nbashkankov/macos-notification-state#fix-monterey-detect",
     "node-mac-permissions": "2.2.1"
   },
   "browserslist": [


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
<!-- Describe your changes in detail. -->
Reverted to older working version.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
Since the upgrade of `macos-notification-state` in #440 , I have been facing issues in the debug console about Do-not-disturb not working. This PR reverts to the older working version.

#### Screenshots
<!-- Remove the section if this does not apply. -->

Before:
<img width="585" alt="Screenshot 2022-08-03 at 6 42 44 AM" src="https://user-images.githubusercontent.com/69629/182502947-f0c5e443-3cb0-4b02-9ffe-23f18194c64d.png">


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
