### PR TITLE
fix: dark mode recipe and app handler

### DIFF
--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -334,10 +334,7 @@ class RecipeController {
       isDarkModeStyleInjected,
     };
 
-    if (
-      this.settings.service.isDarkModeEnabled &&
-      this.settings.app.isDarkThemeActive !== false
-    ) {
+    if (this.settings.service.isDarkModeEnabled) {
       debug('Enable dark mode');
 
       // Check if recipe has a custom dark mode handler


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has _stopped working_ or is _working incorrectly_, please log the bug [here](https://github.com/ferdium/ferdium-recipes/issues)
2. If you are requesting support for a **new service** in Ferdium, please log it [here](https://github.com/ferdium/ferdium-recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/ferdium/ferdium-app#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdium, but to get new recipes between Ferdium releases, this documentation is quite useful.)
4. Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Change how dark mode is activated in recipes. The global app setting shouldn't try to set all recipes to dark and the user should manually do so.

#### Motivation and Context
While working on https://github.com/ferdium/ferdium-recipes/pull/138 I stumble across a problem when trying to activate the dark mode of a recipe while using Ferdium without Dark mode (in the global settings).

After a while at looking at the code I realized that the problem was this line I removed - it was only activating the dark theme on a recipe if `service.isDarkModeEnabled` and `app.isDarkThemeActive` where both true... which I think is unintended, given that a user using the light theme of Ferdium may want to use a dark theme recipe.

I understand that this may need further thinking in the future - maybe with something like: if the user didn't set `service.isDarkModeEnabled` and `app.isDarkThemeActive` then `service.isDarkModeEnabled` should default to `true`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
fix: dark mode recipe and app handler