### PR TITLE
Fix tab item spacing issue

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -278,6 +278,7 @@ function generateServiceRibbonWidthStyle(
     .tab-item {
       width: ${width}px !important;
       height: ${width - tabItemWidthBias}px !important;
+      min-height: ${width - tabItemWidthBias}px !important;
     }
     .tab-item .tab-item__icon {
       width: ${minimumAdjustedIconSize}px !important;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

The `min-height` property set for the `.tab-item` element was not sufficient for the tab items with labels. It causes the item to be cut off by the next item in the list

![image](https://user-images.githubusercontent.com/47709856/195117801-78a6097e-3b5d-42ca-bac0-710f07460ce4.png)

This has been fixed by overriding the value to give sufficient space for the tab items

#### Motivation and Context

Resolves #619

#### Screenshots

After setting the `min-height` to the value of the height being overridden in - `src/features/appearance/index.ts`, the following is the result

<img width="71" alt="image" src="https://user-images.githubusercontent.com/47709856/195109647-adebe3a8-96d1-4def-b0ab-6d47445437ec.png">

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
none
