### PR TITLE
Fix: hide vertical scrollbar when in split view

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -95,6 +95,7 @@ body.win32:not(.isFullScreen) .app .app__content {
 
 .mode__split .app .app__service {
   overflow-x: auto;
+  overflow-y: hidden;
   scroll-snap-type: x proximity;
 }
 


### PR DESCRIPTION
- Resolved #664

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/ferdium/ferdium-app/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
The app displays a vertical scrollbar when in split-view mode which is ambiguous as the individual split pane displays a vertical scrollbar 

![image](https://user-images.githubusercontent.com/47709856/196234557-c0cc385b-7420-4179-b95a-12f273a473d0.png)

#### Motivation and Context
The vertical scrollbar has been hidden for the `.mode__split` selector

![image](https://user-images.githubusercontent.com/47709856/196235424-519e2ae9-1982-45b7-818a-9a2b24a49610.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

- Add `overflow-y: hidden;` to hide vertical scrollbar when in split-view mode