### PR TITLE
chore: remove deprecated @types packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,8 +114,6 @@
         "@types/gulp-sass": "5.0.0",
         "@types/gulp-sass-variables": "1.2.2",
         "@types/gulp-terser": "1.2.1",
-        "@types/gulp-typescript": "2.13.0",
-        "@types/hex-rgb": "4.1.1",
         "@types/jest": "28.1.4",
         "@types/lodash": "4.14.186",
         "@types/mime-types": "2.1.1",
@@ -5025,16 +5023,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@types/gulp-typescript": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/gulp-typescript/-/gulp-typescript-2.13.0.tgz",
-      "integrity": "sha512-LKtclXKmzr4qvxoG/Z9ysRxNCUlU3CpXk2NFxwAONQ5u5cAfsmBZnZP39s2mRwAy+IYTmCGEIOOjlMsct9A6uA==",
-      "deprecated": "This is a stub types definition for gulp-typescript (https://github.com/ivogabe/gulp-typescript). gulp-typescript provides its own type definitions, so you don't need @types/gulp-typescript installed!",
-      "dev": true,
-      "dependencies": {
-        "gulp-typescript": "*"
-      }
-    },
     "node_modules/@types/gulp/node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -5177,16 +5165,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/@types/hex-rgb": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/hex-rgb/-/hex-rgb-4.1.1.tgz",
-      "integrity": "sha512-FHOC5mHnkCnMSzbTJCVnCPqw5TxKABoAkaP1Zdo8p5xa6AS13ty7V8kgpojYt20yIok6wZVlNWRqndUIUuJpKQ==",
-      "deprecated": "This is a stub types definition. hex-rgb provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "hex-rgb": "*"
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -31408,24 +31386,6 @@
             "source-map-support": "~0.5.12"
           }
         }
-      }
-    },
-    "@types/gulp-typescript": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/gulp-typescript/-/gulp-typescript-2.13.0.tgz",
-      "integrity": "sha512-LKtclXKmzr4qvxoG/Z9ysRxNCUlU3CpXk2NFxwAONQ5u5cAfsmBZnZP39s2mRwAy+IYTmCGEIOOjlMsct9A6uA==",
-      "dev": true,
-      "requires": {
-        "gulp-typescript": "*"
-      }
-    },
-    "@types/hex-rgb": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/hex-rgb/-/hex-rgb-4.1.1.tgz",
-      "integrity": "sha512-FHOC5mHnkCnMSzbTJCVnCPqw5TxKABoAkaP1Zdo8p5xa6AS13ty7V8kgpojYt20yIok6wZVlNWRqndUIUuJpKQ==",
-      "dev": true,
-      "requires": {
-        "hex-rgb": "*"
       }
     },
     "@types/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -149,8 +149,6 @@
     "@types/gulp-sass": "5.0.0",
     "@types/gulp-sass-variables": "1.2.2",
     "@types/gulp-terser": "1.2.1",
-    "@types/gulp-typescript": "2.13.0",
-    "@types/hex-rgb": "4.1.1",
     "@types/jest": "28.1.4",
     "@types/lodash": "4.14.186",
     "@types/mime-types": "2.1.1",


### PR DESCRIPTION
After `npm install` I received a deprecated message for the following:

![image](https://user-images.githubusercontent.com/2735602/197590101-f1c1c70e-d9eb-46c6-b104-3998179dc521.png)

Based on that decided to remove these dependencies as these are deprecated.