### PR TITLE
chore: only post stable releases to reddit

### DIFF
--- a/.github/workflows/reddit.yml
+++ b/.github/workflows/reddit.yml
@@ -2,7 +2,7 @@ name: Publish to Reddit
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   test:


### PR DESCRIPTION
As suggested in Discord I think we could improve the Reddit page by only creating posts for stable releases instead of posting all nightly releases as well. Currently the whole Reddit page only contains nightly releases which results in a page full of noise. 