### PR TITLE
fix: ensure default values are working for the Toggle fields

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -338,12 +338,9 @@ export const SERVER_NOT_LOADED = 'Ferdium::SERVER_NOT_LOADED';
 
 export const ALLOWED_PROTOCOLS = ['https:', 'http:', 'ftp:', 'ferdium:'];
 
-export const DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED = false;
-
 export const DEFAULT_TODOS_WIDTH = 300;
 export const TODOS_MIN_WIDTH = 200;
 export const DEFAULT_TODOS_VISIBLE = false;
-export const DEFAULT_IS_FEATURE_ENABLED_BY_USER = true;
 export const DEFAULT_IS_TODO_FEATURE_ENABLED_BY_USER = false;
 export const TODOS_PARTITION_ID = 'persist:todos';
 
@@ -431,9 +428,18 @@ export const DEFAULT_APP_SETTINGS = {
   liftSingleInstanceLock: false,
   enableLongPressServiceHint: false,
   proxyFeatureEnabled: false,
+  proxyHost: '',
+  proxyPort: 0,
+  proxyUser: '',
+  proxyPassword: '',
   onlyShowFavoritesInUnreadCount: false,
   customTodoServer: '',
   locale: 'en-US',
+  keepAllWorkspacesLoaded: false,
+  isFeatureEnabledByUser: true,
+  darkReaderBrightness: 100,
+  darkReaderContrast: 90,
+  darkReaderSepia: 10,
 };
 
 export const DEFAULT_SERVICE_SETTINGS = {

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -193,6 +193,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isEnabled,
             DEFAULT_SERVICE_SETTINGS.isEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isEnabled,
           type: 'checkbox',
         },
         isHibernationEnabled: {
@@ -201,6 +202,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isHibernationEnabled,
             DEFAULT_SERVICE_SETTINGS.isHibernationEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isHibernationEnabled,
           type: 'checkbox',
         },
         isWakeUpEnabled: {
@@ -209,6 +211,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isWakeUpEnabled,
             DEFAULT_SERVICE_SETTINGS.isWakeUpEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isWakeUpEnabled,
           type: 'checkbox',
         },
         isNotificationEnabled: {
@@ -217,6 +220,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isNotificationEnabled,
             DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
           type: 'checkbox',
         },
         isBadgeEnabled: {
@@ -225,6 +229,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isBadgeEnabled,
             DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
           type: 'checkbox',
         },
         isMediaBadgeEnabled: {
@@ -233,6 +238,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isMediaBadgeEnabled,
             DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
           type: 'checkbox',
         },
         trapLinkClicks: {
@@ -241,6 +247,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.trapLinkClicks,
             DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
           type: 'checkbox',
         },
         isMuted: {
@@ -249,6 +256,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isMuted,
             DEFAULT_SERVICE_SETTINGS.isMuted,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isMuted,
           type: 'checkbox',
         },
         customIcon: {
@@ -262,6 +270,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isDarkModeEnabled,
             stores.settings.app.darkMode,
           ),
+          default: stores.settings.app.darkMode,
           type: 'checkbox',
         },
         darkReaderBrightness: {
@@ -269,18 +278,21 @@ class EditServiceScreen extends Component<IProps> {
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.brightness
             : 100,
+          default: 100,
         },
         darkReaderContrast: {
           label: intl.formatMessage(messages.darkReaderContrast),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.contrast
             : 90,
+          default: 90,
         },
         darkReaderSepia: {
           label: intl.formatMessage(messages.darkReaderSepia),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.sepia
             : 10,
+          default: 10,
         },
         isProgressbarEnabled: {
           label: intl.formatMessage(messages.enableProgressbar),
@@ -288,6 +300,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isProgressbarEnabled,
             DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
           type: 'checkbox',
         },
         spellcheckerLanguage: {
@@ -299,7 +312,8 @@ class EditServiceScreen extends Component<IProps> {
         userAgentPref: {
           label: intl.formatMessage(globalMessages.userAgentPref),
           placeholder: service?.defaultUserAgent,
-          value: service?.userAgentPref || '',
+          value: ifUndefined<string>(service?.userAgentPref, ''),
+          default: '',
         },
       },
     };
@@ -350,6 +364,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.isIndirectMessageBadgeEnabled,
             DEFAULT_SERVICE_SETTINGS.hasIndirectMessages,
           ),
+          default: DEFAULT_SERVICE_SETTINGS.hasIndirectMessages,
           type: 'checkbox',
         },
       };
@@ -364,6 +379,7 @@ class EditServiceScreen extends Component<IProps> {
             service?.onlyShowFavoritesInUnreadCount,
             DEFAULT_APP_SETTINGS.onlyShowFavoritesInUnreadCount,
           ),
+          default: DEFAULT_APP_SETTINGS.onlyShowFavoritesInUnreadCount,
           type: 'checkbox',
         },
       };
@@ -374,6 +390,8 @@ class EditServiceScreen extends Component<IProps> {
         ? /*
           TODO - [TS DEBT] find out why sometimes proxy[service.id] gives undefined
           Note in proxy service id exist as key but value is undefined rather that proxy empty object
+
+          Temp fix - or-ed {} (to stores.settings.proxy[service.id] ) to avoid undefined proxy in settingStore throw error
           */
           stores.settings.proxy[service.id] || {}
         : {};
@@ -390,23 +408,28 @@ class EditServiceScreen extends Component<IProps> {
                 serviceProxyConfig.isEnabled,
                 DEFAULT_APP_SETTINGS.proxyFeatureEnabled,
               ),
+              default: DEFAULT_APP_SETTINGS.proxyFeatureEnabled,
               type: 'checkbox',
             },
             host: {
               label: intl.formatMessage(messages.proxyHost),
               value: ifUndefined<string>(serviceProxyConfig.host, ''),
+              default: '',
             },
             port: {
               label: intl.formatMessage(messages.proxyPort),
               value: ifUndefined<number>(serviceProxyConfig.port, 0),
+              default: 0,
             },
             user: {
               label: intl.formatMessage(messages.proxyUser),
               value: ifUndefined<string>(serviceProxyConfig.user, ''),
+              default: '',
             },
             password: {
               label: intl.formatMessage(messages.proxyPassword),
               value: ifUndefined<string>(serviceProxyConfig.password, ''),
+              default: '',
               type: 'password',
             },
           },

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -188,50 +188,52 @@ class EditServiceScreen extends Component<IProps> {
         },
         isEnabled: {
           label: intl.formatMessage(messages.enableService),
-          value: service?.isEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isEnabled,
+          value: service?.isEnabled || DEFAULT_SERVICE_SETTINGS.isEnabled,
           type: 'checkbox',
         },
         isHibernationEnabled: {
           label: intl.formatMessage(messages.enableHibernation),
-          value: service?.isHibernationEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isHibernationEnabled,
+          value:
+            service?.isHibernationEnabled ||
+            DEFAULT_SERVICE_SETTINGS.isHibernationEnabled,
           type: 'checkbox',
         },
         isWakeUpEnabled: {
           label: intl.formatMessage(messages.enableWakeUp),
-          value: service?.isWakeUpEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isWakeUpEnabled,
+          value:
+            service?.isWakeUpEnabled ||
+            DEFAULT_SERVICE_SETTINGS.isWakeUpEnabled,
           type: 'checkbox',
         },
         isNotificationEnabled: {
           label: intl.formatMessage(messages.enableNotification),
-          value: service?.isNotificationEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
+          value:
+            service?.isNotificationEnabled ||
+            DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
           type: 'checkbox',
         },
         isBadgeEnabled: {
           label: intl.formatMessage(messages.enableBadge),
-          value: service?.isBadgeEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
+          value:
+            service?.isBadgeEnabled || DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
           type: 'checkbox',
         },
         isMediaBadgeEnabled: {
           label: intl.formatMessage(messages.enableMediaBadge),
-          value: service?.isMediaBadgeEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
+          value:
+            service?.isMediaBadgeEnabled ||
+            DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
           type: 'checkbox',
         },
         trapLinkClicks: {
           label: intl.formatMessage(messages.trapLinkClicks),
-          value: service?.trapLinkClicks,
-          default: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+          value:
+            service?.trapLinkClicks || DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
           type: 'checkbox',
         },
         isMuted: {
           label: intl.formatMessage(messages.enableAudio),
-          value: !service?.isMuted,
-          default: DEFAULT_SERVICE_SETTINGS.isMuted,
+          value: !service?.isMuted || DEFAULT_SERVICE_SETTINGS.isMuted,
           type: 'checkbox',
         },
         customIcon: {
@@ -242,8 +244,7 @@ class EditServiceScreen extends Component<IProps> {
         },
         isDarkModeEnabled: {
           label: intl.formatMessage(messages.enableDarkMode),
-          value: service?.isDarkModeEnabled,
-          default: stores.settings.app.darkMode,
+          value: service?.isDarkModeEnabled || stores.settings.app.darkMode,
           type: 'checkbox',
         },
         darkReaderBrightness: {
@@ -269,8 +270,9 @@ class EditServiceScreen extends Component<IProps> {
         },
         isProgressbarEnabled: {
           label: intl.formatMessage(messages.enableProgressbar),
-          value: service?.isProgressbarEnabled,
-          default: DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
+          value:
+            service?.isProgressbarEnabled ||
+            DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
           type: 'checkbox',
         },
         spellcheckerLanguage: {
@@ -325,20 +327,28 @@ class EditServiceScreen extends Component<IProps> {
     }
 
     if (recipe.hasIndirectMessages) {
-      config.fields.isIndirectMessageBadgeEnabled = {
-        label: intl.formatMessage(messages.indirectMessages),
-        value: service?.isIndirectMessageBadgeEnabled,
-        default: DEFAULT_SERVICE_SETTINGS.hasIndirectMessages,
-        type: 'checkbox',
+      config.fields = {
+        ...config.fields,
+        isIndirectMessageBadgeEnabled: {
+          label: intl.formatMessage(messages.indirectMessages),
+          value:
+            service?.isIndirectMessageBadgeEnabled ||
+            DEFAULT_SERVICE_SETTINGS.hasIndirectMessages,
+          type: 'checkbox',
+        },
       };
     }
 
     if (recipe.allowFavoritesDelineationInUnreadCount) {
-      config.fields.onlyShowFavoritesInUnreadCount = {
-        label: intl.formatMessage(messages.onlyShowFavoritesInUnreadCount),
-        value: service?.onlyShowFavoritesInUnreadCount,
-        default: DEFAULT_APP_SETTINGS.onlyShowFavoritesInUnreadCount,
-        type: 'checkbox',
+      config.fields = {
+        ...config.fields,
+        onlyShowFavoritesInUnreadCount: {
+          label: intl.formatMessage(messages.onlyShowFavoritesInUnreadCount),
+          value:
+            service?.onlyShowFavoritesInUnreadCount ||
+            DEFAULT_APP_SETTINGS.onlyShowFavoritesInUnreadCount,
+          type: 'checkbox',
+        },
       };
     }
 
@@ -347,42 +357,44 @@ class EditServiceScreen extends Component<IProps> {
         ? /*
           TODO - [TS DEBT] find out why sometimes proxy[service.id] gives undefined
           Note in proxy service id exist as key but value is undefined rather that proxy empty object
-
-          Temp fix - or-ed {} (to stores.settings.proxy[service.id] ) to avoid undefined proxy in settingStore throw error
           */
-          stores.settings.proxy[service.id] || {}
-        : {};
+         stores.settings.proxy[service.id] || {}
+       : {};
 
-      config.fields.proxy = {
-        name: 'proxy',
-        label: 'proxy',
-        fields: {
-          isEnabled: {
-            label: intl.formatMessage(messages.enableProxy),
-            value: serviceProxyConfig.isEnabled,
-            default: DEFAULT_APP_SETTINGS.proxyFeatureEnabled,
-            type: 'checkbox',
-          },
-          host: {
-            label: intl.formatMessage(messages.proxyHost),
-            value: serviceProxyConfig.host,
-            default: '',
-          },
-          port: {
-            label: intl.formatMessage(messages.proxyPort),
-            value: serviceProxyConfig.port,
-            default: '',
-          },
-          user: {
-            label: intl.formatMessage(messages.proxyUser),
-            value: serviceProxyConfig.user,
-            default: '',
-          },
-          password: {
-            label: intl.formatMessage(messages.proxyPassword),
-            value: serviceProxyConfig.password,
-            default: '',
-            type: 'password',
+      config.fields = {
+        ...config.fields,
+        proxy: {
+          name: 'proxy',
+          label: 'proxy',
+          fields: {
+            isEnabled: {
+              label: intl.formatMessage(messages.enableProxy),
+              value:
+                serviceProxyConfig.isEnabled ||
+                DEFAULT_APP_SETTINGS.proxyFeatureEnabled,
+              type: 'checkbox',
+            },
+            host: {
+              label: intl.formatMessage(messages.proxyHost),
+              value: serviceProxyConfig.host,
+              default: '',
+            },
+            port: {
+              label: intl.formatMessage(messages.proxyPort),
+              value: serviceProxyConfig.port,
+              default: '',
+            },
+            user: {
+              label: intl.formatMessage(messages.proxyUser),
+              value: serviceProxyConfig.user,
+              default: '',
+            },
+            password: {
+              label: intl.formatMessage(messages.proxyPassword),
+              value: serviceProxyConfig.password,
+              default: '',
+              type: 'password',
+            },
           },
         },
       };

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -252,7 +252,7 @@ class EditServiceScreen extends Component<IProps> {
         },
         isMuted: {
           label: intl.formatMessage(messages.enableAudio),
-          value: ifUndefined<boolean>(
+          value: !ifUndefined<boolean>(
             service?.isMuted,
             DEFAULT_SERVICE_SETTINGS.isMuted,
           ),

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -277,22 +277,22 @@ class EditServiceScreen extends Component<IProps> {
           label: intl.formatMessage(messages.darkReaderBrightness),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.brightness
-            : 100,
-          default: 100,
+            : DEFAULT_APP_SETTINGS.darkReaderBrightness,
+          default: DEFAULT_APP_SETTINGS.darkReaderBrightness,
         },
         darkReaderContrast: {
           label: intl.formatMessage(messages.darkReaderContrast),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.contrast
-            : 90,
-          default: 90,
+            : DEFAULT_APP_SETTINGS.darkReaderContrast,
+          default: DEFAULT_APP_SETTINGS.darkReaderContrast,
         },
         darkReaderSepia: {
           label: intl.formatMessage(messages.darkReaderSepia),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.sepia
-            : 10,
-          default: 10,
+            : DEFAULT_APP_SETTINGS.darkReaderSepia,
+          default: DEFAULT_APP_SETTINGS.darkReaderSepia,
         },
         isProgressbarEnabled: {
           label: intl.formatMessage(messages.enableProgressbar),
@@ -312,8 +312,11 @@ class EditServiceScreen extends Component<IProps> {
         userAgentPref: {
           label: intl.formatMessage(globalMessages.userAgentPref),
           placeholder: service?.defaultUserAgent,
-          value: ifUndefined<string>(service?.userAgentPref, ''),
-          default: '',
+          value: ifUndefined<string>(
+            service?.userAgentPref,
+            DEFAULT_APP_SETTINGS.userAgentPref,
+          ),
+          default: DEFAULT_APP_SETTINGS.userAgentPref,
         },
       },
     };
@@ -413,23 +416,35 @@ class EditServiceScreen extends Component<IProps> {
             },
             host: {
               label: intl.formatMessage(messages.proxyHost),
-              value: ifUndefined<string>(serviceProxyConfig.host, ''),
-              default: '',
+              value: ifUndefined<string>(
+                serviceProxyConfig.host,
+                DEFAULT_APP_SETTINGS.proxyHost,
+              ),
+              default: DEFAULT_APP_SETTINGS.proxyHost,
             },
             port: {
               label: intl.formatMessage(messages.proxyPort),
-              value: ifUndefined<number>(serviceProxyConfig.port, 0),
-              default: 0,
+              value: ifUndefined<number>(
+                serviceProxyConfig.port,
+                DEFAULT_APP_SETTINGS.proxyPort,
+              ),
+              default: DEFAULT_APP_SETTINGS.proxyPort,
             },
             user: {
               label: intl.formatMessage(messages.proxyUser),
-              value: ifUndefined<string>(serviceProxyConfig.user, ''),
-              default: '',
+              value: ifUndefined<string>(
+                serviceProxyConfig.user,
+                DEFAULT_APP_SETTINGS.proxyUser,
+              ),
+              default: DEFAULT_APP_SETTINGS.proxyUser,
             },
             password: {
               label: intl.formatMessage(messages.proxyPassword),
-              value: ifUndefined<string>(serviceProxyConfig.password, ''),
-              default: '',
+              value: ifUndefined<string>(
+                serviceProxyConfig.password,
+                DEFAULT_APP_SETTINGS.proxyPassword,
+              ),
+              default: DEFAULT_APP_SETTINGS.proxyPassword,
               type: 'password',
             },
           },

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -17,6 +17,7 @@ import { SPELLCHECKER_LOCALES } from '../../i18n/languages';
 import globalMessages from '../../i18n/globalMessages';
 import { DEFAULT_APP_SETTINGS, DEFAULT_SERVICE_SETTINGS } from '../../config';
 import withParams from '../../components/util/WithParams';
+import { ifUndefined } from '../../jsUtils';
 
 const messages = defineMessages({
   name: {
@@ -188,91 +189,105 @@ class EditServiceScreen extends Component<IProps> {
         },
         isEnabled: {
           label: intl.formatMessage(messages.enableService),
-          value: service?.isEnabled || DEFAULT_SERVICE_SETTINGS.isEnabled,
+          value: ifUndefined<boolean>(
+            service?.isEnabled,
+            DEFAULT_SERVICE_SETTINGS.isEnabled,
+          ),
           type: 'checkbox',
         },
         isHibernationEnabled: {
           label: intl.formatMessage(messages.enableHibernation),
-          value:
-            service?.isHibernationEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isHibernationEnabled,
             DEFAULT_SERVICE_SETTINGS.isHibernationEnabled,
+          ),
           type: 'checkbox',
         },
         isWakeUpEnabled: {
           label: intl.formatMessage(messages.enableWakeUp),
-          value:
-            service?.isWakeUpEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isWakeUpEnabled,
             DEFAULT_SERVICE_SETTINGS.isWakeUpEnabled,
+          ),
           type: 'checkbox',
         },
         isNotificationEnabled: {
           label: intl.formatMessage(messages.enableNotification),
-          value:
-            service?.isNotificationEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isNotificationEnabled,
             DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
+          ),
           type: 'checkbox',
         },
         isBadgeEnabled: {
           label: intl.formatMessage(messages.enableBadge),
-          value:
-            service?.isBadgeEnabled || DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
+          value: ifUndefined<boolean>(
+            service?.isBadgeEnabled,
+            DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
+          ),
           type: 'checkbox',
         },
         isMediaBadgeEnabled: {
           label: intl.formatMessage(messages.enableMediaBadge),
-          value:
-            service?.isMediaBadgeEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isMediaBadgeEnabled,
             DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
+          ),
           type: 'checkbox',
         },
         trapLinkClicks: {
           label: intl.formatMessage(messages.trapLinkClicks),
-          value:
-            service?.trapLinkClicks || DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+          value: ifUndefined<boolean>(
+            service?.trapLinkClicks,
+            DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+          ),
           type: 'checkbox',
         },
         isMuted: {
           label: intl.formatMessage(messages.enableAudio),
-          value: !service?.isMuted || DEFAULT_SERVICE_SETTINGS.isMuted,
+          value: ifUndefined<boolean>(
+            service?.isMuted,
+            DEFAULT_SERVICE_SETTINGS.isMuted,
+          ),
           type: 'checkbox',
         },
         customIcon: {
           label: intl.formatMessage(messages.icon),
           value: service?.hasCustomUploadedIcon ? service?.icon : false,
-          default: null,
           type: 'file',
         },
         isDarkModeEnabled: {
           label: intl.formatMessage(messages.enableDarkMode),
-          value: service?.isDarkModeEnabled || stores.settings.app.darkMode,
+          value: ifUndefined<boolean>(
+            service?.isDarkModeEnabled,
+            stores.settings.app.darkMode,
+          ),
           type: 'checkbox',
         },
         darkReaderBrightness: {
           label: intl.formatMessage(messages.darkReaderBrightness),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.brightness
-            : undefined,
-          default: 100,
+            : 100,
         },
         darkReaderContrast: {
           label: intl.formatMessage(messages.darkReaderContrast),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.contrast
-            : undefined,
-          default: 90,
+            : 90,
         },
         darkReaderSepia: {
           label: intl.formatMessage(messages.darkReaderSepia),
           value: service?.darkReaderSettings
             ? service?.darkReaderSettings.sepia
-            : undefined,
-          default: 10,
+            : 10,
         },
         isProgressbarEnabled: {
           label: intl.formatMessage(messages.enableProgressbar),
-          value:
-            service?.isProgressbarEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isProgressbarEnabled,
             DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
+          ),
           type: 'checkbox',
         },
         spellcheckerLanguage: {
@@ -331,9 +346,10 @@ class EditServiceScreen extends Component<IProps> {
         ...config.fields,
         isIndirectMessageBadgeEnabled: {
           label: intl.formatMessage(messages.indirectMessages),
-          value:
-            service?.isIndirectMessageBadgeEnabled ||
+          value: ifUndefined<boolean>(
+            service?.isIndirectMessageBadgeEnabled,
             DEFAULT_SERVICE_SETTINGS.hasIndirectMessages,
+          ),
           type: 'checkbox',
         },
       };
@@ -344,9 +360,10 @@ class EditServiceScreen extends Component<IProps> {
         ...config.fields,
         onlyShowFavoritesInUnreadCount: {
           label: intl.formatMessage(messages.onlyShowFavoritesInUnreadCount),
-          value:
-            service?.onlyShowFavoritesInUnreadCount ||
+          value: ifUndefined<boolean>(
+            service?.onlyShowFavoritesInUnreadCount,
             DEFAULT_APP_SETTINGS.onlyShowFavoritesInUnreadCount,
+          ),
           type: 'checkbox',
         },
       };
@@ -358,8 +375,8 @@ class EditServiceScreen extends Component<IProps> {
           TODO - [TS DEBT] find out why sometimes proxy[service.id] gives undefined
           Note in proxy service id exist as key but value is undefined rather that proxy empty object
           */
-         stores.settings.proxy[service.id] || {}
-       : {};
+          stores.settings.proxy[service.id] || {}
+        : {};
 
       config.fields = {
         ...config.fields,
@@ -369,30 +386,27 @@ class EditServiceScreen extends Component<IProps> {
           fields: {
             isEnabled: {
               label: intl.formatMessage(messages.enableProxy),
-              value:
-                serviceProxyConfig.isEnabled ||
+              value: ifUndefined<boolean>(
+                serviceProxyConfig.isEnabled,
                 DEFAULT_APP_SETTINGS.proxyFeatureEnabled,
+              ),
               type: 'checkbox',
             },
             host: {
               label: intl.formatMessage(messages.proxyHost),
-              value: serviceProxyConfig.host,
-              default: '',
+              value: ifUndefined<string>(serviceProxyConfig.host, ''),
             },
             port: {
               label: intl.formatMessage(messages.proxyPort),
-              value: serviceProxyConfig.port,
-              default: '',
+              value: ifUndefined<number>(serviceProxyConfig.port, 0),
             },
             user: {
               label: intl.formatMessage(messages.proxyUser),
-              value: serviceProxyConfig.user,
-              default: '',
+              value: ifUndefined<string>(serviceProxyConfig.user, ''),
             },
             password: {
               label: intl.formatMessage(messages.proxyPassword),
-              value: serviceProxyConfig.password,
-              default: '',
+              value: ifUndefined<string>(serviceProxyConfig.password, ''),
               type: 'password',
             },
           },

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -547,6 +547,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             app.autoLaunchOnStart,
             DEFAULT_APP_SETTINGS.autoLaunchOnStart,
           ),
+          default: DEFAULT_APP_SETTINGS.autoLaunchOnStart,
           type: 'checkbox',
         },
         autoLaunchInBackground: {
@@ -555,6 +556,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             app.launchInBackground,
             DEFAULT_APP_SETTINGS.autoLaunchInBackground,
           ),
+          default: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
           type: 'checkbox',
         },
         runInBackground: {
@@ -563,6 +565,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.runInBackground,
             DEFAULT_APP_SETTINGS.runInBackground,
           ),
+          default: DEFAULT_APP_SETTINGS.runInBackground,
           type: 'checkbox',
         },
         startMinimized: {
@@ -571,6 +574,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.startMinimized,
             DEFAULT_APP_SETTINGS.startMinimized,
           ),
+          default: DEFAULT_APP_SETTINGS.startMinimized,
           type: 'checkbox',
         },
         confirmOnQuit: {
@@ -579,6 +583,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.confirmOnQuit,
             DEFAULT_APP_SETTINGS.confirmOnQuit,
           ),
+          default: DEFAULT_APP_SETTINGS.confirmOnQuit,
           type: 'checkbox',
         },
         enableSystemTray: {
@@ -589,6 +594,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableSystemTray,
             DEFAULT_APP_SETTINGS.enableSystemTray,
           ),
+          default: DEFAULT_APP_SETTINGS.enableSystemTray,
           type: 'checkbox',
         },
         reloadAfterResume: {
@@ -597,6 +603,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.reloadAfterResume,
             DEFAULT_APP_SETTINGS.reloadAfterResume,
           ),
+          default: DEFAULT_APP_SETTINGS.reloadAfterResume,
           type: 'checkbox',
         },
         reloadAfterResumeTime: {
@@ -605,6 +612,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.reloadAfterResumeTime,
             DEFAULT_APP_SETTINGS.reloadAfterResumeTime,
           ),
+          default: DEFAULT_APP_SETTINGS.reloadAfterResumeTime,
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
@@ -612,6 +620,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.minimizeToSystemTray,
             DEFAULT_APP_SETTINGS.minimizeToSystemTray,
           ),
+          default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
           type: 'checkbox',
         },
         closeToSystemTray: {
@@ -620,6 +629,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.closeToSystemTray,
             DEFAULT_APP_SETTINGS.closeToSystemTray,
           ),
+          default: DEFAULT_APP_SETTINGS.closeToSystemTray,
           type: 'checkbox',
         },
         privateNotifications: {
@@ -628,6 +638,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.privateNotifications,
             DEFAULT_APP_SETTINGS.privateNotifications,
           ),
+          default: DEFAULT_APP_SETTINGS.privateNotifications,
           type: 'checkbox',
         },
         clipboardNotifications: {
@@ -636,6 +647,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.clipboardNotifications,
             DEFAULT_APP_SETTINGS.clipboardNotifications,
           ),
+          default: DEFAULT_APP_SETTINGS.clipboardNotifications,
           type: 'checkbox',
         },
         notifyTaskBarOnMessage: {
@@ -644,6 +656,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.notifyTaskBarOnMessage,
             DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
           ),
+          default: DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
           type: 'checkbox',
         },
         navigationBarBehaviour: {
@@ -652,6 +665,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.navigationBarBehaviour,
             DEFAULT_APP_SETTINGS.navigationBarBehaviour,
           ),
+          default: DEFAULT_APP_SETTINGS.navigationBarBehaviour,
           options: navigationBarBehaviours,
         },
         webRTCIPHandlingPolicy: {
@@ -660,6 +674,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.webRTCIPHandlingPolicy,
             DEFAULT_APP_SETTINGS.webRTCIPHandlingPolicy,
           ),
+          default: DEFAULT_APP_SETTINGS.webRTCIPHandlingPolicy,
           options: webRTCIPHandlingPolicies,
           type: 'checkbox',
         },
@@ -669,6 +684,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.searchEngine,
             DEFAULT_APP_SETTINGS.searchEngine,
           ),
+          default: DEFAULT_APP_SETTINGS.searchEngine,
           options: searchEngines,
         },
         translatorEngine: {
@@ -677,6 +693,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.translatorEngine,
             DEFAULT_APP_SETTINGS.translatorEngine,
           ),
+          default: DEFAULT_APP_SETTINGS.translatorEngine,
           options: translatorEngines,
         },
         translatorLanguage: {
@@ -685,6 +702,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.translatorLanguage,
             DEFAULT_APP_SETTINGS.translatorLanguage,
           ),
+          default: DEFAULT_APP_SETTINGS.translatorLanguage,
           options: translatorLanguages,
         },
         sentry: {
@@ -693,6 +711,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.sentry,
             DEFAULT_APP_SETTINGS.sentry,
           ),
+          default: DEFAULT_APP_SETTINGS.sentry,
           type: 'checkbox',
         },
         hibernateOnStartup: {
@@ -701,6 +720,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hibernateOnStartup,
             DEFAULT_APP_SETTINGS.hibernateOnStartup,
           ),
+          default: DEFAULT_APP_SETTINGS.hibernateOnStartup,
           type: 'checkbox',
         },
         hibernationStrategy: {
@@ -709,6 +729,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hibernationStrategy,
             DEFAULT_APP_SETTINGS.hibernationStrategy,
           ),
+          default: DEFAULT_APP_SETTINGS.hibernationStrategy,
           options: hibernationStrategies,
         },
         wakeUpStrategy: {
@@ -717,6 +738,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.wakeUpStrategy,
             DEFAULT_APP_SETTINGS.wakeUpStrategy,
           ),
+          default: DEFAULT_APP_SETTINGS.wakeUpStrategy,
           options: wakeUpStrategies,
         },
         wakeUpHibernationStrategy: {
@@ -725,6 +747,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.wakeUpHibernationStrategy,
             DEFAULT_APP_SETTINGS.wakeUpHibernationStrategy,
           ),
+          default: DEFAULT_APP_SETTINGS.wakeUpHibernationStrategy,
           options: wakeUpHibernationStrategies,
         },
         wakeUpHibernationSplay: {
@@ -733,6 +756,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.wakeUpHibernationSplay,
             DEFAULT_APP_SETTINGS.wakeUpHibernationSplay,
           ),
+          default: DEFAULT_APP_SETTINGS.wakeUpHibernationSplay,
           type: 'checkbox',
         },
         predefinedTodoServer: {
@@ -741,6 +765,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.predefinedTodoServer,
             DEFAULT_APP_SETTINGS.predefinedTodoServer,
           ),
+          default: DEFAULT_APP_SETTINGS.predefinedTodoServer,
           options: todoApp,
         },
         customTodoServer: {
@@ -749,6 +774,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.customTodoServer,
             DEFAULT_APP_SETTINGS.customTodoServer,
           ),
+          default: DEFAULT_APP_SETTINGS.customTodoServer,
         },
         lockingFeatureEnabled: {
           label: intl.formatMessage(messages.enableLock),
@@ -756,11 +782,13 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.lockingFeatureEnabled,
             DEFAULT_APP_SETTINGS.lockingFeatureEnabled,
           ),
+          default: DEFAULT_APP_SETTINGS.lockingFeatureEnabled,
           type: 'checkbox',
         },
         lockedPassword: {
           label: intl.formatMessage(messages.lockPassword),
           value: ifUndefined<string>(lockedPassword, ''),
+          default: '',
           type: 'password',
         },
         useTouchIdToUnlock: {
@@ -769,11 +797,13 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.useTouchIdToUnlock,
             DEFAULT_APP_SETTINGS.useTouchIdToUnlock,
           ),
+          default: DEFAULT_APP_SETTINGS.useTouchIdToUnlock,
           type: 'checkbox',
         },
         inactivityLock: {
           label: intl.formatMessage(messages.inactivityLock),
           value: ifUndefined<number>(settings.all.app.inactivityLock, 0),
+          default: 0,
           type: 'number',
         },
         scheduledDNDEnabled: {
@@ -782,6 +812,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.scheduledDNDEnabled,
             DEFAULT_APP_SETTINGS.scheduledDNDEnabled,
           ),
+          default: DEFAULT_APP_SETTINGS.scheduledDNDEnabled,
           type: 'checkbox',
         },
         scheduledDNDStart: {
@@ -790,11 +821,13 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.scheduledDNDStart,
             '17:00',
           ),
+          default: '17:00',
           type: 'time',
         },
         scheduledDNDEnd: {
           label: intl.formatMessage(messages.scheduledDNDEnd),
           value: ifUndefined<string>(settings.all.app.scheduledDNDEnd, '09:00'),
+          default: '09:00',
           type: 'time',
         },
         showDisabledServices: {
@@ -803,6 +836,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.showDisabledServices,
             DEFAULT_APP_SETTINGS.showDisabledServices,
           ),
+          default: DEFAULT_APP_SETTINGS.showDisabledServices,
           type: 'checkbox',
         },
         showServiceName: {
@@ -811,6 +845,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.showServiceName,
             DEFAULT_APP_SETTINGS.showServiceName,
           ),
+          default: DEFAULT_APP_SETTINGS.showServiceName,
         },
         showMessageBadgeWhenMuted: {
           label: intl.formatMessage(messages.showMessageBadgeWhenMuted),
@@ -818,6 +853,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.showMessageBadgeWhenMuted,
             DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
           ),
+          default: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
           type: 'checkbox',
         },
         showDragArea: {
@@ -826,6 +862,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.showDragArea,
             DEFAULT_APP_SETTINGS.showDragArea,
           ),
+          default: DEFAULT_APP_SETTINGS.showDragArea,
           type: 'checkbox',
         },
         enableSpellchecking: {
@@ -834,6 +871,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableSpellchecking,
             DEFAULT_APP_SETTINGS.enableSpellchecking,
           ),
+          default: DEFAULT_APP_SETTINGS.enableSpellchecking,
           type: 'checkbox',
         },
         enableTranslator: {
@@ -842,6 +880,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableTranslator,
             DEFAULT_APP_SETTINGS.enableTranslator,
           ),
+          default: DEFAULT_APP_SETTINGS.enableTranslator,
           type: 'checkbox',
         },
         spellcheckerLanguage: {
@@ -850,6 +889,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.spellcheckerLanguage,
             DEFAULT_APP_SETTINGS.spellcheckerLanguage,
           ),
+          default: DEFAULT_APP_SETTINGS.spellcheckerLanguage,
           options: spellcheckingLanguages,
         },
         userAgentPref: {
@@ -858,6 +898,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.userAgentPref,
             DEFAULT_APP_SETTINGS.userAgentPref,
           ),
+          default: DEFAULT_APP_SETTINGS.userAgentPref,
           placeholder: defaultUserAgent(),
         },
         darkMode: {
@@ -866,6 +907,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.darkMode,
             DEFAULT_APP_SETTINGS.darkMode,
           ),
+          default: DEFAULT_APP_SETTINGS.darkMode,
           type: 'checkbox',
         },
         adaptableDarkMode: {
@@ -874,6 +916,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.adaptableDarkMode,
             DEFAULT_APP_SETTINGS.adaptableDarkMode,
           ),
+          default: DEFAULT_APP_SETTINGS.adaptableDarkMode,
           type: 'checkbox',
         },
         universalDarkMode: {
@@ -882,6 +925,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.universalDarkMode,
             DEFAULT_APP_SETTINGS.universalDarkMode,
           ),
+          default: DEFAULT_APP_SETTINGS.universalDarkMode,
           type: 'checkbox',
         },
         splitMode: {
@@ -890,6 +934,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.splitMode,
             DEFAULT_APP_SETTINGS.splitMode,
           ),
+          default: DEFAULT_APP_SETTINGS.splitMode,
           type: 'checkbox',
         },
         splitColumns: {
@@ -900,6 +945,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.splitColumns,
             DEFAULT_APP_SETTINGS.splitColumns,
           ),
+          default: DEFAULT_APP_SETTINGS.splitColumns,
         },
         serviceRibbonWidth: {
           label: intl.formatMessage(messages.serviceRibbonWidth),
@@ -907,6 +953,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.serviceRibbonWidth,
             DEFAULT_APP_SETTINGS.serviceRibbonWidth,
           ),
+          default: DEFAULT_APP_SETTINGS.serviceRibbonWidth,
           options: sidebarWidth,
         },
         sidebarServicesLocation: {
@@ -915,6 +962,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.sidebarServicesLocation,
             DEFAULT_APP_SETTINGS.sidebarServicesLocation,
           ),
+          default: DEFAULT_APP_SETTINGS.sidebarServicesLocation,
           options: sidebarServicesLocation,
         },
         iconSize: {
@@ -923,6 +971,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.iconSize,
             DEFAULT_APP_SETTINGS.iconSize,
           ),
+          default: DEFAULT_APP_SETTINGS.iconSize,
           options: iconSizes,
         },
         enableLongPressServiceHint: {
@@ -931,6 +980,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableLongPressServiceHint,
             DEFAULT_APP_SETTINGS.enableLongPressServiceHint,
           ),
+          default: DEFAULT_APP_SETTINGS.enableLongPressServiceHint,
           type: 'checkbox',
         },
         useHorizontalStyle: {
@@ -939,6 +989,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.useHorizontalStyle,
             DEFAULT_APP_SETTINGS.useHorizontalStyle,
           ),
+          default: DEFAULT_APP_SETTINGS.useHorizontalStyle,
           type: 'checkbox',
         },
         hideCollapseButton: {
@@ -947,6 +998,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideCollapseButton,
             DEFAULT_APP_SETTINGS.hideCollapseButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideCollapseButton,
           type: 'checkbox',
         },
         hideRecipesButton: {
@@ -955,6 +1007,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideRecipesButton,
             DEFAULT_APP_SETTINGS.hideRecipesButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideRecipesButton,
           type: 'checkbox',
         },
         hideSplitModeButton: {
@@ -963,6 +1016,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideSplitModeButton,
             DEFAULT_APP_SETTINGS.hideSplitModeButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideSplitModeButton,
           type: 'checkbox',
         },
         useGrayscaleServices: {
@@ -971,6 +1025,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.useGrayscaleServices,
             DEFAULT_APP_SETTINGS.useGrayscaleServices,
           ),
+          default: DEFAULT_APP_SETTINGS.useGrayscaleServices,
           type: 'checkbox',
         },
         grayscaleServicesDim: {
@@ -979,6 +1034,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.grayscaleServicesDim,
             DEFAULT_APP_SETTINGS.grayscaleServicesDim,
           ),
+          default: DEFAULT_APP_SETTINGS.grayscaleServicesDim,
         },
         hideWorkspacesButton: {
           label: intl.formatMessage(messages.hideWorkspacesButton),
@@ -986,6 +1042,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideWorkspacesButton,
             DEFAULT_APP_SETTINGS.hideWorkspacesButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideWorkspacesButton,
           type: 'checkbox',
         },
         hideNotificationsButton: {
@@ -994,6 +1051,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideNotificationsButton,
             DEFAULT_APP_SETTINGS.hideNotificationsButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideNotificationsButton,
           type: 'checkbox',
         },
         hideSettingsButton: {
@@ -1002,6 +1060,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.hideSettingsButton,
             DEFAULT_APP_SETTINGS.hideSettingsButton,
           ),
+          default: DEFAULT_APP_SETTINGS.hideSettingsButton,
           type: 'checkbox',
         },
         alwaysShowWorkspaces: {
@@ -1010,6 +1069,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.alwaysShowWorkspaces,
             DEFAULT_APP_SETTINGS.alwaysShowWorkspaces,
           ),
+          default: DEFAULT_APP_SETTINGS.alwaysShowWorkspaces,
           type: 'checkbox',
         },
         accentColor: {
@@ -1018,6 +1078,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.accentColor,
             DEFAULT_APP_SETTINGS.accentColor,
           ),
+          default: DEFAULT_APP_SETTINGS.accentColor,
         },
         progressbarAccentColor: {
           label: intl.formatMessage(messages.progressbarAccentColor),
@@ -1025,6 +1086,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.progressbarAccentColor,
             DEFAULT_APP_SETTINGS.progressbarAccentColor,
           ),
+          default: DEFAULT_APP_SETTINGS.progressbarAccentColor,
         },
         enableGPUAcceleration: {
           label: intl.formatMessage(messages.enableGPUAcceleration),
@@ -1032,6 +1094,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableGPUAcceleration,
             DEFAULT_APP_SETTINGS.enableGPUAcceleration,
           ),
+          default: DEFAULT_APP_SETTINGS.enableGPUAcceleration,
           type: 'checkbox',
         },
         enableGlobalHideShortcut: {
@@ -1040,11 +1103,13 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.all.app.enableGlobalHideShortcut,
             DEFAULT_APP_SETTINGS.enableGlobalHideShortcut,
           ),
+          default: DEFAULT_APP_SETTINGS.enableGlobalHideShortcut,
           type: 'checkbox',
         },
         locale: {
           label: intl.formatMessage(messages.language),
           value: ifUndefined<string>(app.locale, DEFAULT_APP_SETTINGS.locale),
+          default: DEFAULT_APP_SETTINGS.locale,
           options: locales,
         },
         beta: {
@@ -1053,6 +1118,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             user.data.beta,
             DEFAULT_APP_SETTINGS.beta,
           ),
+          default: DEFAULT_APP_SETTINGS.beta,
           type: 'checkbox',
         },
         automaticUpdates: {
@@ -1061,6 +1127,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
             settings.app.automaticUpdates,
             DEFAULT_APP_SETTINGS.automaticUpdates,
           ),
+          default: DEFAULT_APP_SETTINGS.automaticUpdates,
           type: 'checkbox',
         },
       },
@@ -1081,6 +1148,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
           workspaces.settings.keepAllWorkspacesLoaded,
           DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
         ),
+        default: DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
         type: 'checkbox',
       };
     }
@@ -1092,6 +1160,7 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
           todos.settings.isFeatureEnabledByUser,
           DEFAULT_IS_FEATURE_ENABLED_BY_USER,
         ),
+        default: DEFAULT_IS_FEATURE_ENABLED_BY_USER,
         type: 'checkbox',
       };
     }

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -39,6 +39,7 @@ import ErrorBoundary from '../../components/util/ErrorBoundary';
 
 import globalMessages from '../../i18n/globalMessages';
 import { importExportURL } from '../../api/apiBase';
+import { ifUndefined } from '../../jsUtils';
 
 const debug = require('../../preload-safe-debug')('Ferdium:EditSettingsScreen');
 
@@ -542,437 +543,524 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
       fields: {
         autoLaunchOnStart: {
           label: intl.formatMessage(messages.autoLaunchOnStart),
-          value:
-            app.autoLaunchOnStart || DEFAULT_APP_SETTINGS.autoLaunchOnStart,
+          value: ifUndefined<boolean>(
+            app.autoLaunchOnStart,
+            DEFAULT_APP_SETTINGS.autoLaunchOnStart,
+          ),
           type: 'checkbox',
         },
         autoLaunchInBackground: {
           label: intl.formatMessage(messages.autoLaunchInBackground),
-          value:
-            app.launchInBackground ||
+          value: ifUndefined<boolean>(
+            app.launchInBackground,
             DEFAULT_APP_SETTINGS.autoLaunchInBackground,
+          ),
           type: 'checkbox',
         },
         runInBackground: {
           label: intl.formatMessage(messages.runInBackground),
-          value:
-            settings.all.app.runInBackground ||
+          value: ifUndefined<boolean>(
+            settings.all.app.runInBackground,
             DEFAULT_APP_SETTINGS.runInBackground,
+          ),
           type: 'checkbox',
         },
         startMinimized: {
           label: intl.formatMessage(messages.startMinimized),
-          value:
-            settings.all.app.startMinimized ||
+          value: ifUndefined<boolean>(
+            settings.all.app.startMinimized,
             DEFAULT_APP_SETTINGS.startMinimized,
+          ),
           type: 'checkbox',
         },
         confirmOnQuit: {
           label: intl.formatMessage(messages.confirmOnQuit),
-          value:
-            settings.all.app.confirmOnQuit ||
+          value: ifUndefined<boolean>(
+            settings.all.app.confirmOnQuit,
             DEFAULT_APP_SETTINGS.confirmOnQuit,
+          ),
           type: 'checkbox',
         },
         enableSystemTray: {
           label: intl.formatMessage(
             isMac ? messages.enableMenuBar : messages.enableSystemTray,
           ),
-          value:
-            settings.all.app.enableSystemTray ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableSystemTray,
             DEFAULT_APP_SETTINGS.enableSystemTray,
+          ),
           type: 'checkbox',
         },
         reloadAfterResume: {
           label: intl.formatMessage(messages.reloadAfterResume),
-          value:
-            settings.all.app.reloadAfterResume ||
+          value: ifUndefined<boolean>(
+            settings.all.app.reloadAfterResume,
             DEFAULT_APP_SETTINGS.reloadAfterResume,
+          ),
           type: 'checkbox',
         },
         reloadAfterResumeTime: {
           label: intl.formatMessage(messages.reloadAfterResumeTime),
-          value: settings.all.app.reloadAfterResumeTime,
-          default: DEFAULT_APP_SETTINGS.reloadAfterResumeTime,
+          value: ifUndefined<number>(
+            settings.all.app.reloadAfterResumeTime,
+            DEFAULT_APP_SETTINGS.reloadAfterResumeTime,
+          ),
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
-          value:
-            settings.all.app.minimizeToSystemTray ||
+          value: ifUndefined<boolean>(
+            settings.all.app.minimizeToSystemTray,
             DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+          ),
           type: 'checkbox',
         },
         closeToSystemTray: {
           label: intl.formatMessage(messages.closeToSystemTray),
-          value:
-            settings.all.app.closeToSystemTray ||
+          value: ifUndefined<boolean>(
+            settings.all.app.closeToSystemTray,
             DEFAULT_APP_SETTINGS.closeToSystemTray,
+          ),
           type: 'checkbox',
         },
         privateNotifications: {
           label: intl.formatMessage(messages.privateNotifications),
-          value:
-            settings.all.app.privateNotifications ||
+          value: ifUndefined<boolean>(
+            settings.all.app.privateNotifications,
             DEFAULT_APP_SETTINGS.privateNotifications,
+          ),
           type: 'checkbox',
         },
         clipboardNotifications: {
           label: intl.formatMessage(messages.clipboardNotifications),
-          value:
-            settings.all.app.clipboardNotifications ||
+          value: ifUndefined<boolean>(
+            settings.all.app.clipboardNotifications,
             DEFAULT_APP_SETTINGS.clipboardNotifications,
+          ),
           type: 'checkbox',
         },
         notifyTaskBarOnMessage: {
           label: intl.formatMessage(messages.notifyTaskBarOnMessage),
-          value:
-            settings.all.app.notifyTaskBarOnMessage ||
+          value: ifUndefined<boolean>(
+            settings.all.app.notifyTaskBarOnMessage,
             DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
+          ),
           type: 'checkbox',
         },
         navigationBarBehaviour: {
           label: intl.formatMessage(messages.navigationBarBehaviour),
-          value: settings.all.app.navigationBarBehaviour,
-          default: DEFAULT_APP_SETTINGS.navigationBarBehaviour,
+          value: ifUndefined<string>(
+            settings.all.app.navigationBarBehaviour,
+            DEFAULT_APP_SETTINGS.navigationBarBehaviour,
+          ),
           options: navigationBarBehaviours,
         },
         webRTCIPHandlingPolicy: {
           label: intl.formatMessage(messages.webRTCIPHandlingPolicy),
-          value:
-            settings.all.app.webRTCIPHandlingPolicy ||
+          value: ifUndefined<string>(
+            settings.all.app.webRTCIPHandlingPolicy,
             DEFAULT_APP_SETTINGS.webRTCIPHandlingPolicy,
+          ),
           options: webRTCIPHandlingPolicies,
           type: 'checkbox',
         },
         searchEngine: {
           label: intl.formatMessage(messages.searchEngine),
-          value: settings.all.app.searchEngine,
-          default: DEFAULT_APP_SETTINGS.searchEngine,
+          value: ifUndefined<string>(
+            settings.all.app.searchEngine,
+            DEFAULT_APP_SETTINGS.searchEngine,
+          ),
           options: searchEngines,
         },
         translatorEngine: {
           label: intl.formatMessage(messages.translatorEngine),
-          value: settings.all.app.translatorEngine,
-          default: DEFAULT_APP_SETTINGS.translatorEngine,
+          value: ifUndefined<string>(
+            settings.all.app.translatorEngine,
+            DEFAULT_APP_SETTINGS.translatorEngine,
+          ),
           options: translatorEngines,
         },
         translatorLanguage: {
           label: intl.formatMessage(messages.translatorLanguage),
-          value: settings.all.app.translatorLanguage,
-          default: DEFAULT_APP_SETTINGS.translatorLanguage,
+          value: ifUndefined<string>(
+            settings.all.app.translatorLanguage,
+            DEFAULT_APP_SETTINGS.translatorLanguage,
+          ),
           options: translatorLanguages,
         },
         sentry: {
           label: intl.formatMessage(messages.sentry),
-          value: settings.all.app.sentry || DEFAULT_APP_SETTINGS.sentry,
+          value: ifUndefined<boolean>(
+            settings.all.app.sentry,
+            DEFAULT_APP_SETTINGS.sentry,
+          ),
           type: 'checkbox',
         },
         hibernateOnStartup: {
           label: intl.formatMessage(messages.hibernateOnStartup),
-          value:
-            settings.all.app.hibernateOnStartup ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hibernateOnStartup,
             DEFAULT_APP_SETTINGS.hibernateOnStartup,
+          ),
           type: 'checkbox',
         },
         hibernationStrategy: {
           label: intl.formatMessage(messages.hibernationStrategy),
-          value: settings.all.app.hibernationStrategy,
+          value: ifUndefined<string>(
+            settings.all.app.hibernationStrategy,
+            DEFAULT_APP_SETTINGS.hibernationStrategy,
+          ),
           options: hibernationStrategies,
-          default: DEFAULT_APP_SETTINGS.hibernationStrategy,
         },
         wakeUpStrategy: {
           label: intl.formatMessage(messages.wakeUpStrategy),
-          value: settings.all.app.wakeUpStrategy,
+          value: ifUndefined<string>(
+            settings.all.app.wakeUpStrategy,
+            DEFAULT_APP_SETTINGS.wakeUpStrategy,
+          ),
           options: wakeUpStrategies,
-          default: DEFAULT_APP_SETTINGS.wakeUpStrategy,
         },
         wakeUpHibernationStrategy: {
           label: intl.formatMessage(messages.wakeUpHibernationStrategy),
-          value: settings.all.app.wakeUpHibernationStrategy,
+          value: ifUndefined<string>(
+            settings.all.app.wakeUpHibernationStrategy,
+            DEFAULT_APP_SETTINGS.wakeUpHibernationStrategy,
+          ),
           options: wakeUpHibernationStrategies,
-          default: DEFAULT_APP_SETTINGS.wakeUpHibernationStrategy,
         },
         wakeUpHibernationSplay: {
           label: intl.formatMessage(messages.wakeUpHibernationSplay),
-          value:
-            settings.all.app.wakeUpHibernationSplay ||
+          value: ifUndefined<boolean>(
+            settings.all.app.wakeUpHibernationSplay,
             DEFAULT_APP_SETTINGS.wakeUpHibernationSplay,
+          ),
           type: 'checkbox',
         },
         predefinedTodoServer: {
           label: intl.formatMessage(messages.predefinedTodoServer),
-          value: settings.all.app.predefinedTodoServer,
-          default: DEFAULT_APP_SETTINGS.predefinedTodoServer,
+          value: ifUndefined<string>(
+            settings.all.app.predefinedTodoServer,
+            DEFAULT_APP_SETTINGS.predefinedTodoServer,
+          ),
           options: todoApp,
         },
         customTodoServer: {
           label: intl.formatMessage(messages.customTodoServer),
-          value: settings.all.app.customTodoServer,
-          default: DEFAULT_APP_SETTINGS.customTodoServer,
+          value: ifUndefined<string>(
+            settings.all.app.customTodoServer,
+            DEFAULT_APP_SETTINGS.customTodoServer,
+          ),
         },
         lockingFeatureEnabled: {
           label: intl.formatMessage(messages.enableLock),
-          value:
-            settings.all.app.lockingFeatureEnabled ||
+          value: ifUndefined<boolean>(
+            settings.all.app.lockingFeatureEnabled,
             DEFAULT_APP_SETTINGS.lockingFeatureEnabled,
+          ),
           type: 'checkbox',
         },
         lockedPassword: {
           label: intl.formatMessage(messages.lockPassword),
-          value: lockedPassword,
-          default: '',
+          value: ifUndefined<string>(lockedPassword, ''),
           type: 'password',
         },
         useTouchIdToUnlock: {
           label: intl.formatMessage(messages.useTouchIdToUnlock),
-          value:
-            settings.all.app.useTouchIdToUnlock ||
+          value: ifUndefined<boolean>(
+            settings.all.app.useTouchIdToUnlock,
             DEFAULT_APP_SETTINGS.useTouchIdToUnlock,
+          ),
           type: 'checkbox',
         },
         inactivityLock: {
           label: intl.formatMessage(messages.inactivityLock),
-          value: settings.all.app.inactivityLock,
-          default: 0,
+          value: ifUndefined<number>(settings.all.app.inactivityLock, 0),
           type: 'number',
         },
         scheduledDNDEnabled: {
           label: intl.formatMessage(messages.scheduledDNDEnabled),
-          value:
-            settings.all.app.scheduledDNDEnabled ||
+          value: ifUndefined<boolean>(
+            settings.all.app.scheduledDNDEnabled,
             DEFAULT_APP_SETTINGS.scheduledDNDEnabled,
+          ),
           type: 'checkbox',
         },
         scheduledDNDStart: {
           label: intl.formatMessage(messages.scheduledDNDStart),
-          value: settings.all.app.scheduledDNDStart,
-          default: '17:00',
+          value: ifUndefined<string>(
+            settings.all.app.scheduledDNDStart,
+            '17:00',
+          ),
           type: 'time',
         },
         scheduledDNDEnd: {
           label: intl.formatMessage(messages.scheduledDNDEnd),
-          value: settings.all.app.scheduledDNDEnd,
-          default: '09:00',
+          value: ifUndefined<string>(settings.all.app.scheduledDNDEnd, '09:00'),
           type: 'time',
         },
         showDisabledServices: {
           label: intl.formatMessage(messages.showDisabledServices),
-          value:
-            settings.all.app.showDisabledServices ||
+          value: ifUndefined<boolean>(
+            settings.all.app.showDisabledServices,
             DEFAULT_APP_SETTINGS.showDisabledServices,
+          ),
           type: 'checkbox',
         },
         showServiceName: {
           label: intl.formatMessage(messages.showServiceName),
-          value:
-            settings.all.app.showServiceName ||
+          value: ifUndefined<boolean>(
+            settings.all.app.showServiceName,
             DEFAULT_APP_SETTINGS.showServiceName,
-          type: 'checkbox',
+          ),
         },
         showMessageBadgeWhenMuted: {
           label: intl.formatMessage(messages.showMessageBadgeWhenMuted),
-          value:
-            settings.all.app.showMessageBadgeWhenMuted ||
+          value: ifUndefined<boolean>(
+            settings.all.app.showMessageBadgeWhenMuted,
             DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
+          ),
           type: 'checkbox',
         },
         showDragArea: {
           label: intl.formatMessage(messages.showDragArea),
-          value: settings.all.app.showDragArea,
-          default: DEFAULT_APP_SETTINGS.showDragArea,
+          value: ifUndefined<boolean>(
+            settings.all.app.showDragArea,
+            DEFAULT_APP_SETTINGS.showDragArea,
+          ),
           type: 'checkbox',
         },
         enableSpellchecking: {
           label: intl.formatMessage(messages.enableSpellchecking),
-          value:
-            settings.all.app.enableSpellchecking ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableSpellchecking,
             DEFAULT_APP_SETTINGS.enableSpellchecking,
+          ),
           type: 'checkbox',
         },
         enableTranslator: {
           label: intl.formatMessage(messages.enableTranslator),
-          value:
-            settings.all.app.enableTranslator ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableTranslator,
             DEFAULT_APP_SETTINGS.enableTranslator,
+          ),
           type: 'checkbox',
         },
         spellcheckerLanguage: {
           label: intl.formatMessage(globalMessages.spellcheckerLanguage),
-          value: settings.all.app.spellcheckerLanguage,
+          value: ifUndefined<string>(
+            settings.all.app.spellcheckerLanguage,
+            DEFAULT_APP_SETTINGS.spellcheckerLanguage,
+          ),
           options: spellcheckingLanguages,
-          default: DEFAULT_APP_SETTINGS.spellcheckerLanguage,
         },
         userAgentPref: {
           label: intl.formatMessage(globalMessages.userAgentPref),
-          value: settings.all.app.userAgentPref,
-          default: DEFAULT_APP_SETTINGS.userAgentPref,
+          value: ifUndefined<string>(
+            settings.all.app.userAgentPref,
+            DEFAULT_APP_SETTINGS.userAgentPref,
+          ),
           placeholder: defaultUserAgent(),
         },
         darkMode: {
           label: intl.formatMessage(messages.darkMode),
-          value: settings.all.app.darkMode || DEFAULT_APP_SETTINGS.darkMode,
+          value: ifUndefined<boolean>(
+            settings.all.app.darkMode,
+            DEFAULT_APP_SETTINGS.darkMode,
+          ),
           type: 'checkbox',
         },
         adaptableDarkMode: {
           label: intl.formatMessage(messages.adaptableDarkMode),
-          value:
-            settings.all.app.adaptableDarkMode ||
+          value: ifUndefined<boolean>(
+            settings.all.app.adaptableDarkMode,
             DEFAULT_APP_SETTINGS.adaptableDarkMode,
+          ),
           type: 'checkbox',
         },
         universalDarkMode: {
           label: intl.formatMessage(messages.universalDarkMode),
-          value:
-            settings.all.app.universalDarkMode ||
+          value: ifUndefined<boolean>(
+            settings.all.app.universalDarkMode,
             DEFAULT_APP_SETTINGS.universalDarkMode,
+          ),
           type: 'checkbox',
         },
         splitMode: {
           label: intl.formatMessage(messages.splitMode),
-          value: settings.all.app.splitMode || DEFAULT_APP_SETTINGS.splitMode,
+          value: ifUndefined<boolean>(
+            settings.all.app.splitMode,
+            DEFAULT_APP_SETTINGS.splitMode,
+          ),
           type: 'checkbox',
         },
         splitColumns: {
           label: `${intl.formatMessage(
             messages.splitColumns,
           )} (${SPLIT_COLUMNS_MIN}-${SPLIT_COLUMNS_MAX})`,
-          value: settings.all.app.splitColumns,
-          default: DEFAULT_APP_SETTINGS.splitColumns,
+          value: ifUndefined<number>(
+            settings.all.app.splitColumns,
+            DEFAULT_APP_SETTINGS.splitColumns,
+          ),
         },
         serviceRibbonWidth: {
           label: intl.formatMessage(messages.serviceRibbonWidth),
-          value: settings.all.app.serviceRibbonWidth,
-          default: DEFAULT_APP_SETTINGS.serviceRibbonWidth,
+          value: ifUndefined<number>(
+            settings.all.app.serviceRibbonWidth,
+            DEFAULT_APP_SETTINGS.serviceRibbonWidth,
+          ),
           options: sidebarWidth,
         },
         sidebarServicesLocation: {
           label: intl.formatMessage(messages.sidebarServicesLocation),
-          value: settings.all.app.sidebarServicesLocation,
-          default: DEFAULT_APP_SETTINGS.sidebarServicesLocation,
+          value: ifUndefined<number>(
+            settings.all.app.sidebarServicesLocation,
+            DEFAULT_APP_SETTINGS.sidebarServicesLocation,
+          ),
           options: sidebarServicesLocation,
         },
         iconSize: {
           label: intl.formatMessage(messages.iconSize),
-          value: settings.all.app.iconSize,
-          default: DEFAULT_APP_SETTINGS.iconSize,
+          value: ifUndefined<number>(
+            settings.all.app.iconSize,
+            DEFAULT_APP_SETTINGS.iconSize,
+          ),
           options: iconSizes,
         },
         enableLongPressServiceHint: {
           label: intl.formatMessage(messages.enableLongPressServiceHint),
-          value:
-            settings.all.app.enableLongPressServiceHint ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableLongPressServiceHint,
             DEFAULT_APP_SETTINGS.enableLongPressServiceHint,
+          ),
           type: 'checkbox',
         },
         useHorizontalStyle: {
           label: intl.formatMessage(messages.useHorizontalStyle),
-          value:
-            settings.all.app.useHorizontalStyle ||
+          value: ifUndefined<boolean>(
+            settings.all.app.useHorizontalStyle,
             DEFAULT_APP_SETTINGS.useHorizontalStyle,
+          ),
           type: 'checkbox',
         },
         hideCollapseButton: {
           label: intl.formatMessage(messages.hideCollapseButton),
-          value:
-            settings.all.app.hideCollapseButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideCollapseButton,
             DEFAULT_APP_SETTINGS.hideCollapseButton,
+          ),
           type: 'checkbox',
         },
         hideRecipesButton: {
           label: intl.formatMessage(messages.hideRecipesButton),
-          value:
-            settings.all.app.hideRecipesButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideRecipesButton,
             DEFAULT_APP_SETTINGS.hideRecipesButton,
+          ),
           type: 'checkbox',
         },
         hideSplitModeButton: {
           label: intl.formatMessage(messages.hideSplitModeButton),
-          value:
-            settings.all.app.hideSplitModeButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideSplitModeButton,
             DEFAULT_APP_SETTINGS.hideSplitModeButton,
+          ),
           type: 'checkbox',
         },
         useGrayscaleServices: {
           label: intl.formatMessage(messages.useGrayscaleServices),
-          value:
-            settings.all.app.useGrayscaleServices ||
+          value: ifUndefined<boolean>(
+            settings.all.app.useGrayscaleServices,
             DEFAULT_APP_SETTINGS.useGrayscaleServices,
+          ),
           type: 'checkbox',
         },
         grayscaleServicesDim: {
           label: intl.formatMessage(messages.grayscaleServicesDim),
-          value: settings.all.app.grayscaleServicesDim,
-          default: DEFAULT_APP_SETTINGS.grayscaleServicesDim,
+          value: ifUndefined<number>(
+            settings.all.app.grayscaleServicesDim,
+            DEFAULT_APP_SETTINGS.grayscaleServicesDim,
+          ),
         },
         hideWorkspacesButton: {
           label: intl.formatMessage(messages.hideWorkspacesButton),
-          value:
-            settings.all.app.hideWorkspacesButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideWorkspacesButton,
             DEFAULT_APP_SETTINGS.hideWorkspacesButton,
+          ),
           type: 'checkbox',
         },
         hideNotificationsButton: {
           label: intl.formatMessage(messages.hideNotificationsButton),
-          value:
-            settings.all.app.hideNotificationsButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideNotificationsButton,
             DEFAULT_APP_SETTINGS.hideNotificationsButton,
+          ),
           type: 'checkbox',
         },
         hideSettingsButton: {
           label: intl.formatMessage(messages.hideSettingsButton),
-          value:
-            settings.all.app.hideSettingsButton ||
+          value: ifUndefined<boolean>(
+            settings.all.app.hideSettingsButton,
             DEFAULT_APP_SETTINGS.hideSettingsButton,
+          ),
           type: 'checkbox',
         },
         alwaysShowWorkspaces: {
           label: intl.formatMessage(messages.alwaysShowWorkspaces),
-          value:
-            settings.all.app.alwaysShowWorkspaces ||
+          value: ifUndefined<boolean>(
+            settings.all.app.alwaysShowWorkspaces,
             DEFAULT_APP_SETTINGS.alwaysShowWorkspaces,
+          ),
           type: 'checkbox',
         },
         accentColor: {
           label: intl.formatMessage(messages.accentColor),
-          value: settings.all.app.accentColor,
-          default: DEFAULT_APP_SETTINGS.accentColor,
+          value: ifUndefined<string>(
+            settings.all.app.accentColor,
+            DEFAULT_APP_SETTINGS.accentColor,
+          ),
         },
         progressbarAccentColor: {
           label: intl.formatMessage(messages.progressbarAccentColor),
-          value: settings.all.app.progressbarAccentColor,
-          default: DEFAULT_APP_SETTINGS.progressbarAccentColor,
+          value: ifUndefined<string>(
+            settings.all.app.progressbarAccentColor,
+            DEFAULT_APP_SETTINGS.progressbarAccentColor,
+          ),
         },
         enableGPUAcceleration: {
           label: intl.formatMessage(messages.enableGPUAcceleration),
-          value:
-            settings.all.app.enableGPUAcceleration ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableGPUAcceleration,
             DEFAULT_APP_SETTINGS.enableGPUAcceleration,
+          ),
           type: 'checkbox',
         },
         enableGlobalHideShortcut: {
           label: intl.formatMessage(messages.enableGlobalHideShortcut),
-          value:
-            settings.all.app.enableGlobalHideShortcut ||
+          value: ifUndefined<boolean>(
+            settings.all.app.enableGlobalHideShortcut,
             DEFAULT_APP_SETTINGS.enableGlobalHideShortcut,
+          ),
           type: 'checkbox',
         },
         locale: {
           label: intl.formatMessage(messages.language),
-          value: app.locale,
+          value: ifUndefined<string>(app.locale, DEFAULT_APP_SETTINGS.locale),
           options: locales,
-          default: DEFAULT_APP_SETTINGS.locale,
         },
         beta: {
           label: intl.formatMessage(messages.beta),
-          value: user.data.beta,
-          default: DEFAULT_APP_SETTINGS.beta,
+          value: ifUndefined<boolean>(
+            user.data.beta,
+            DEFAULT_APP_SETTINGS.beta,
+          ),
           type: 'checkbox',
         },
         automaticUpdates: {
           label: intl.formatMessage(messages.automaticUpdates),
-          value:
-            settings.app.automaticUpdates ||
+          value: ifUndefined<boolean>(
+            settings.app.automaticUpdates,
             DEFAULT_APP_SETTINGS.automaticUpdates,
+          ),
           type: 'checkbox',
         },
       },
@@ -989,9 +1077,10 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
     if (workspaces.isFeatureActive) {
       config.fields.keepAllWorkspacesLoaded = {
         label: intl.formatMessage(messages.keepAllWorkspacesLoaded),
-        value:
-          workspaces.settings.keepAllWorkspacesLoaded ||
+        value: ifUndefined<boolean>(
+          workspaces.settings.keepAllWorkspacesLoaded,
           DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
+        ),
         type: 'checkbox',
       };
     }
@@ -999,9 +1088,10 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
     if (todos.isFeatureActive) {
       config.fields.enableTodos = {
         label: intl.formatMessage(messages.enableTodos),
-        value:
-          todos.settings.isFeatureEnabledByUser ||
+        value: ifUndefined<boolean>(
+          todos.settings.isFeatureEnabledByUser,
           DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+        ),
         type: 'checkbox',
       };
     }

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -542,46 +542,52 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
       fields: {
         autoLaunchOnStart: {
           label: intl.formatMessage(messages.autoLaunchOnStart),
-          value: app.autoLaunchOnStart,
-          default: DEFAULT_APP_SETTINGS.autoLaunchOnStart,
+          value:
+            app.autoLaunchOnStart || DEFAULT_APP_SETTINGS.autoLaunchOnStart,
           type: 'checkbox',
         },
         autoLaunchInBackground: {
           label: intl.formatMessage(messages.autoLaunchInBackground),
-          value: app.launchInBackground,
-          default: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
+          value:
+            app.launchInBackground ||
+            DEFAULT_APP_SETTINGS.autoLaunchInBackground,
           type: 'checkbox',
         },
         runInBackground: {
           label: intl.formatMessage(messages.runInBackground),
-          value: settings.all.app.runInBackground,
-          default: DEFAULT_APP_SETTINGS.runInBackground,
+          value:
+            settings.all.app.runInBackground ||
+            DEFAULT_APP_SETTINGS.runInBackground,
           type: 'checkbox',
         },
         startMinimized: {
           label: intl.formatMessage(messages.startMinimized),
-          value: settings.all.app.startMinimized,
-          default: DEFAULT_APP_SETTINGS.startMinimized,
+          value:
+            settings.all.app.startMinimized ||
+            DEFAULT_APP_SETTINGS.startMinimized,
           type: 'checkbox',
         },
         confirmOnQuit: {
           label: intl.formatMessage(messages.confirmOnQuit),
-          value: settings.all.app.confirmOnQuit,
-          default: DEFAULT_APP_SETTINGS.confirmOnQuit,
+          value:
+            settings.all.app.confirmOnQuit ||
+            DEFAULT_APP_SETTINGS.confirmOnQuit,
           type: 'checkbox',
         },
         enableSystemTray: {
           label: intl.formatMessage(
             isMac ? messages.enableMenuBar : messages.enableSystemTray,
           ),
-          value: settings.all.app.enableSystemTray,
-          default: DEFAULT_APP_SETTINGS.enableSystemTray,
+          value:
+            settings.all.app.enableSystemTray ||
+            DEFAULT_APP_SETTINGS.enableSystemTray,
           type: 'checkbox',
         },
         reloadAfterResume: {
           label: intl.formatMessage(messages.reloadAfterResume),
-          value: settings.all.app.reloadAfterResume,
-          default: DEFAULT_APP_SETTINGS.reloadAfterResume,
+          value:
+            settings.all.app.reloadAfterResume ||
+            DEFAULT_APP_SETTINGS.reloadAfterResume,
           type: 'checkbox',
         },
         reloadAfterResumeTime: {
@@ -591,32 +597,37 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
-          value: settings.all.app.minimizeToSystemTray,
-          default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+          value:
+            settings.all.app.minimizeToSystemTray ||
+            DEFAULT_APP_SETTINGS.minimizeToSystemTray,
           type: 'checkbox',
         },
         closeToSystemTray: {
           label: intl.formatMessage(messages.closeToSystemTray),
-          value: settings.all.app.closeToSystemTray,
-          default: DEFAULT_APP_SETTINGS.closeToSystemTray,
+          value:
+            settings.all.app.closeToSystemTray ||
+            DEFAULT_APP_SETTINGS.closeToSystemTray,
           type: 'checkbox',
         },
         privateNotifications: {
           label: intl.formatMessage(messages.privateNotifications),
-          value: settings.all.app.privateNotifications,
-          default: DEFAULT_APP_SETTINGS.privateNotifications,
+          value:
+            settings.all.app.privateNotifications ||
+            DEFAULT_APP_SETTINGS.privateNotifications,
           type: 'checkbox',
         },
         clipboardNotifications: {
           label: intl.formatMessage(messages.clipboardNotifications),
-          value: settings.all.app.clipboardNotifications,
-          default: DEFAULT_APP_SETTINGS.clipboardNotifications,
+          value:
+            settings.all.app.clipboardNotifications ||
+            DEFAULT_APP_SETTINGS.clipboardNotifications,
           type: 'checkbox',
         },
         notifyTaskBarOnMessage: {
           label: intl.formatMessage(messages.notifyTaskBarOnMessage),
-          value: settings.all.app.notifyTaskBarOnMessage,
-          default: DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
+          value:
+            settings.all.app.notifyTaskBarOnMessage ||
+            DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
           type: 'checkbox',
         },
         navigationBarBehaviour: {
@@ -627,8 +638,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         webRTCIPHandlingPolicy: {
           label: intl.formatMessage(messages.webRTCIPHandlingPolicy),
-          value: settings.all.app.webRTCIPHandlingPolicy,
-          default: DEFAULT_APP_SETTINGS.webRTCIPHandlingPolicy,
+          value:
+            settings.all.app.webRTCIPHandlingPolicy ||
+            DEFAULT_APP_SETTINGS.webRTCIPHandlingPolicy,
           options: webRTCIPHandlingPolicies,
           type: 'checkbox',
         },
@@ -652,14 +664,14 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         sentry: {
           label: intl.formatMessage(messages.sentry),
-          value: settings.all.app.sentry,
-          default: DEFAULT_APP_SETTINGS.sentry,
+          value: settings.all.app.sentry || DEFAULT_APP_SETTINGS.sentry,
           type: 'checkbox',
         },
         hibernateOnStartup: {
           label: intl.formatMessage(messages.hibernateOnStartup),
-          value: settings.all.app.hibernateOnStartup,
-          default: DEFAULT_APP_SETTINGS.hibernateOnStartup,
+          value:
+            settings.all.app.hibernateOnStartup ||
+            DEFAULT_APP_SETTINGS.hibernateOnStartup,
           type: 'checkbox',
         },
         hibernationStrategy: {
@@ -682,8 +694,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         wakeUpHibernationSplay: {
           label: intl.formatMessage(messages.wakeUpHibernationSplay),
-          value: settings.all.app.wakeUpHibernationSplay,
-          default: DEFAULT_APP_SETTINGS.wakeUpHibernationSplay,
+          value:
+            settings.all.app.wakeUpHibernationSplay ||
+            DEFAULT_APP_SETTINGS.wakeUpHibernationSplay,
           type: 'checkbox',
         },
         predefinedTodoServer: {
@@ -699,8 +712,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         lockingFeatureEnabled: {
           label: intl.formatMessage(messages.enableLock),
-          value: settings.all.app.lockingFeatureEnabled || false,
-          default: DEFAULT_APP_SETTINGS.lockingFeatureEnabled,
+          value:
+            settings.all.app.lockingFeatureEnabled ||
+            DEFAULT_APP_SETTINGS.lockingFeatureEnabled,
           type: 'checkbox',
         },
         lockedPassword: {
@@ -711,8 +725,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         useTouchIdToUnlock: {
           label: intl.formatMessage(messages.useTouchIdToUnlock),
-          value: settings.all.app.useTouchIdToUnlock,
-          default: DEFAULT_APP_SETTINGS.useTouchIdToUnlock,
+          value:
+            settings.all.app.useTouchIdToUnlock ||
+            DEFAULT_APP_SETTINGS.useTouchIdToUnlock,
           type: 'checkbox',
         },
         inactivityLock: {
@@ -723,8 +738,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         scheduledDNDEnabled: {
           label: intl.formatMessage(messages.scheduledDNDEnabled),
-          value: settings.all.app.scheduledDNDEnabled || false,
-          default: DEFAULT_APP_SETTINGS.scheduledDNDEnabled,
+          value:
+            settings.all.app.scheduledDNDEnabled ||
+            DEFAULT_APP_SETTINGS.scheduledDNDEnabled,
           type: 'checkbox',
         },
         scheduledDNDStart: {
@@ -741,20 +757,23 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         showDisabledServices: {
           label: intl.formatMessage(messages.showDisabledServices),
-          value: settings.all.app.showDisabledServices,
-          default: DEFAULT_APP_SETTINGS.showDisabledServices,
+          value:
+            settings.all.app.showDisabledServices ||
+            DEFAULT_APP_SETTINGS.showDisabledServices,
           type: 'checkbox',
         },
         showServiceName: {
           label: intl.formatMessage(messages.showServiceName),
-          value: settings.all.app.showServiceName,
-          default: DEFAULT_APP_SETTINGS.showServiceName,
+          value:
+            settings.all.app.showServiceName ||
+            DEFAULT_APP_SETTINGS.showServiceName,
           type: 'checkbox',
         },
         showMessageBadgeWhenMuted: {
           label: intl.formatMessage(messages.showMessageBadgeWhenMuted),
-          value: settings.all.app.showMessageBadgeWhenMuted,
-          default: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
+          value:
+            settings.all.app.showMessageBadgeWhenMuted ||
+            DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
           type: 'checkbox',
         },
         showDragArea: {
@@ -765,14 +784,16 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         enableSpellchecking: {
           label: intl.formatMessage(messages.enableSpellchecking),
-          value: settings.all.app.enableSpellchecking,
-          default: DEFAULT_APP_SETTINGS.enableSpellchecking,
+          value:
+            settings.all.app.enableSpellchecking ||
+            DEFAULT_APP_SETTINGS.enableSpellchecking,
           type: 'checkbox',
         },
         enableTranslator: {
           label: intl.formatMessage(messages.enableTranslator),
-          value: settings.all.app.enableTranslator,
-          default: DEFAULT_APP_SETTINGS.enableTranslator,
+          value:
+            settings.all.app.enableTranslator ||
+            DEFAULT_APP_SETTINGS.enableTranslator,
           type: 'checkbox',
         },
         spellcheckerLanguage: {
@@ -789,26 +810,26 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         darkMode: {
           label: intl.formatMessage(messages.darkMode),
-          value: settings.all.app.darkMode,
-          default: DEFAULT_APP_SETTINGS.darkMode,
+          value: settings.all.app.darkMode || DEFAULT_APP_SETTINGS.darkMode,
           type: 'checkbox',
         },
         adaptableDarkMode: {
           label: intl.formatMessage(messages.adaptableDarkMode),
-          value: settings.all.app.adaptableDarkMode,
-          default: DEFAULT_APP_SETTINGS.adaptableDarkMode,
+          value:
+            settings.all.app.adaptableDarkMode ||
+            DEFAULT_APP_SETTINGS.adaptableDarkMode,
           type: 'checkbox',
         },
         universalDarkMode: {
           label: intl.formatMessage(messages.universalDarkMode),
-          value: settings.all.app.universalDarkMode,
-          default: DEFAULT_APP_SETTINGS.universalDarkMode,
+          value:
+            settings.all.app.universalDarkMode ||
+            DEFAULT_APP_SETTINGS.universalDarkMode,
           type: 'checkbox',
         },
         splitMode: {
           label: intl.formatMessage(messages.splitMode),
-          value: settings.all.app.splitMode,
-          default: DEFAULT_APP_SETTINGS.splitMode,
+          value: settings.all.app.splitMode || DEFAULT_APP_SETTINGS.splitMode,
           type: 'checkbox',
         },
         splitColumns: {
@@ -838,38 +859,44 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         enableLongPressServiceHint: {
           label: intl.formatMessage(messages.enableLongPressServiceHint),
-          value: settings.all.app.enableLongPressServiceHint,
-          default: DEFAULT_APP_SETTINGS.enableLongPressServiceHint,
+          value:
+            settings.all.app.enableLongPressServiceHint ||
+            DEFAULT_APP_SETTINGS.enableLongPressServiceHint,
           type: 'checkbox',
         },
         useHorizontalStyle: {
           label: intl.formatMessage(messages.useHorizontalStyle),
-          value: settings.all.app.useHorizontalStyle,
-          default: DEFAULT_APP_SETTINGS.useHorizontalStyle,
+          value:
+            settings.all.app.useHorizontalStyle ||
+            DEFAULT_APP_SETTINGS.useHorizontalStyle,
           type: 'checkbox',
         },
         hideCollapseButton: {
           label: intl.formatMessage(messages.hideCollapseButton),
-          value: settings.all.app.hideCollapseButton,
-          default: DEFAULT_APP_SETTINGS.hideCollapseButton,
+          value:
+            settings.all.app.hideCollapseButton ||
+            DEFAULT_APP_SETTINGS.hideCollapseButton,
           type: 'checkbox',
         },
         hideRecipesButton: {
           label: intl.formatMessage(messages.hideRecipesButton),
-          value: settings.all.app.hideRecipesButton,
-          default: DEFAULT_APP_SETTINGS.hideRecipesButton,
+          value:
+            settings.all.app.hideRecipesButton ||
+            DEFAULT_APP_SETTINGS.hideRecipesButton,
           type: 'checkbox',
         },
         hideSplitModeButton: {
           label: intl.formatMessage(messages.hideSplitModeButton),
-          value: settings.all.app.hideSplitModeButton,
-          default: DEFAULT_APP_SETTINGS.hideSplitModeButton,
+          value:
+            settings.all.app.hideSplitModeButton ||
+            DEFAULT_APP_SETTINGS.hideSplitModeButton,
           type: 'checkbox',
         },
         useGrayscaleServices: {
           label: intl.formatMessage(messages.useGrayscaleServices),
-          value: settings.all.app.useGrayscaleServices,
-          default: DEFAULT_APP_SETTINGS.useGrayscaleServices,
+          value:
+            settings.all.app.useGrayscaleServices ||
+            DEFAULT_APP_SETTINGS.useGrayscaleServices,
           type: 'checkbox',
         },
         grayscaleServicesDim: {
@@ -879,26 +906,30 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         hideWorkspacesButton: {
           label: intl.formatMessage(messages.hideWorkspacesButton),
-          value: settings.all.app.hideWorkspacesButton,
-          default: DEFAULT_APP_SETTINGS.hideWorkspacesButton,
+          value:
+            settings.all.app.hideWorkspacesButton ||
+            DEFAULT_APP_SETTINGS.hideWorkspacesButton,
           type: 'checkbox',
         },
         hideNotificationsButton: {
           label: intl.formatMessage(messages.hideNotificationsButton),
-          value: settings.all.app.hideNotificationsButton,
-          default: DEFAULT_APP_SETTINGS.hideNotificationsButton,
+          value:
+            settings.all.app.hideNotificationsButton ||
+            DEFAULT_APP_SETTINGS.hideNotificationsButton,
           type: 'checkbox',
         },
         hideSettingsButton: {
           label: intl.formatMessage(messages.hideSettingsButton),
-          value: settings.all.app.hideSettingsButton,
-          default: DEFAULT_APP_SETTINGS.hideSettingsButton,
+          value:
+            settings.all.app.hideSettingsButton ||
+            DEFAULT_APP_SETTINGS.hideSettingsButton,
           type: 'checkbox',
         },
         alwaysShowWorkspaces: {
           label: intl.formatMessage(messages.alwaysShowWorkspaces),
-          value: settings.all.app.alwaysShowWorkspaces,
-          default: DEFAULT_APP_SETTINGS.alwaysShowWorkspaces,
+          value:
+            settings.all.app.alwaysShowWorkspaces ||
+            DEFAULT_APP_SETTINGS.alwaysShowWorkspaces,
           type: 'checkbox',
         },
         accentColor: {
@@ -913,14 +944,16 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         enableGPUAcceleration: {
           label: intl.formatMessage(messages.enableGPUAcceleration),
-          value: settings.all.app.enableGPUAcceleration,
-          default: DEFAULT_APP_SETTINGS.enableGPUAcceleration,
+          value:
+            settings.all.app.enableGPUAcceleration ||
+            DEFAULT_APP_SETTINGS.enableGPUAcceleration,
           type: 'checkbox',
         },
         enableGlobalHideShortcut: {
           label: intl.formatMessage(messages.enableGlobalHideShortcut),
-          value: settings.all.app.enableGlobalHideShortcut,
-          default: DEFAULT_APP_SETTINGS.enableGlobalHideShortcut,
+          value:
+            settings.all.app.enableGlobalHideShortcut ||
+            DEFAULT_APP_SETTINGS.enableGlobalHideShortcut,
           type: 'checkbox',
         },
         locale: {
@@ -937,8 +970,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         automaticUpdates: {
           label: intl.formatMessage(messages.automaticUpdates),
-          value: settings.app.automaticUpdates,
-          default: DEFAULT_APP_SETTINGS.automaticUpdates,
+          value:
+            settings.app.automaticUpdates ||
+            DEFAULT_APP_SETTINGS.automaticUpdates,
           type: 'checkbox',
         },
       },
@@ -955,8 +989,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
     if (workspaces.isFeatureActive) {
       config.fields.keepAllWorkspacesLoaded = {
         label: intl.formatMessage(messages.keepAllWorkspacesLoaded),
-        value: workspaces.settings.keepAllWorkspacesLoaded,
-        default: DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
+        value:
+          workspaces.settings.keepAllWorkspacesLoaded ||
+          DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
         type: 'checkbox',
       };
     }
@@ -964,8 +999,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
     if (todos.isFeatureActive) {
       config.fields.enableTodos = {
         label: intl.formatMessage(messages.enableTodos),
-        value: todos.settings.isFeatureEnabledByUser,
-        default: DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+        value:
+          todos.settings.isFeatureEnabledByUser ||
+          DEFAULT_IS_FEATURE_ENABLED_BY_USER,
         type: 'checkbox',
       };
     }

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -20,8 +20,6 @@ import {
   TRANSLATOR_ENGINE_GOOGLE,
   LIBRETRANSLATE_TRANSLATOR_LANGUAGES,
   TODO_APPS,
-  DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
-  DEFAULT_IS_FEATURE_ENABLED_BY_USER,
   WAKE_UP_STRATEGIES,
   WAKE_UP_HIBERNATION_STRATEGIES,
   SPLIT_COLUMNS_MIN,
@@ -787,8 +785,11 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         lockedPassword: {
           label: intl.formatMessage(messages.lockPassword),
-          value: ifUndefined<string>(lockedPassword, ''),
-          default: '',
+          value: ifUndefined<string>(
+            lockedPassword,
+            DEFAULT_APP_SETTINGS.lockedPassword,
+          ),
+          default: DEFAULT_APP_SETTINGS.lockedPassword,
           type: 'password',
         },
         useTouchIdToUnlock: {
@@ -802,8 +803,11 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         },
         inactivityLock: {
           label: intl.formatMessage(messages.inactivityLock),
-          value: ifUndefined<number>(settings.all.app.inactivityLock, 0),
-          default: 0,
+          value: ifUndefined<number>(
+            settings.all.app.inactivityLock,
+            DEFAULT_APP_SETTINGS.inactivityLock,
+          ),
+          default: DEFAULT_APP_SETTINGS.inactivityLock,
           type: 'number',
         },
         scheduledDNDEnabled: {
@@ -819,15 +823,18 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
           label: intl.formatMessage(messages.scheduledDNDStart),
           value: ifUndefined<string>(
             settings.all.app.scheduledDNDStart,
-            '17:00',
+            DEFAULT_APP_SETTINGS.scheduledDNDStart,
           ),
-          default: '17:00',
+          default: DEFAULT_APP_SETTINGS.scheduledDNDStart,
           type: 'time',
         },
         scheduledDNDEnd: {
           label: intl.formatMessage(messages.scheduledDNDEnd),
-          value: ifUndefined<string>(settings.all.app.scheduledDNDEnd, '09:00'),
-          default: '09:00',
+          value: ifUndefined<string>(
+            settings.all.app.scheduledDNDEnd,
+            DEFAULT_APP_SETTINGS.scheduledDNDEnd,
+          ),
+          default: DEFAULT_APP_SETTINGS.scheduledDNDEnd,
           type: 'time',
         },
         showDisabledServices: {
@@ -1146,9 +1153,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         label: intl.formatMessage(messages.keepAllWorkspacesLoaded),
         value: ifUndefined<boolean>(
           workspaces.settings.keepAllWorkspacesLoaded,
-          DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
+          DEFAULT_APP_SETTINGS.keepAllWorkspacesLoaded,
         ),
-        default: DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED,
+        default: DEFAULT_APP_SETTINGS.keepAllWorkspacesLoaded,
         type: 'checkbox',
       };
     }
@@ -1158,9 +1165,9 @@ class EditSettingsScreen extends Component<EditSettingsScreenProps> {
         label: intl.formatMessage(messages.enableTodos),
         value: ifUndefined<boolean>(
           todos.settings.isFeatureEnabledByUser,
-          DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+          DEFAULT_APP_SETTINGS.isFeatureEnabledByUser,
         ),
-        default: DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+        default: DEFAULT_APP_SETTINGS.isFeatureEnabledByUser,
         type: 'checkbox',
       };
     }

--- a/src/features/todos/store.ts
+++ b/src/features/todos/store.ts
@@ -19,6 +19,7 @@ import Reaction, { createReactions } from '../../stores/lib/Reaction';
 import { createActionBindings } from '../utils/ActionBinding';
 import { IPC, TODOS_ROUTES } from './constants';
 import UserAgent from '../../models/UserAgent';
+import { ifUndefined } from '../../jsUtils';
 
 const debug = require('../../preload-safe-debug')(
   'Ferdium:feature:todos:store',
@@ -46,7 +47,7 @@ export default class TodoStore extends FeatureStore {
   }
 
   @computed get width() {
-    const width = this.settings.width || DEFAULT_TODOS_WIDTH;
+    const width = ifUndefined<number>(this.settings.width, DEFAULT_TODOS_WIDTH);
 
     return width < TODOS_MIN_WIDTH ? TODOS_MIN_WIDTH : width;
   }
@@ -56,10 +57,10 @@ export default class TodoStore extends FeatureStore {
   }
 
   @computed get isTodosPanelVisible() {
-    if (this.settings.isTodosPanelVisible === undefined) {
-      return DEFAULT_TODOS_VISIBLE;
-    }
-    return this.settings.isTodosPanelVisible;
+    return ifUndefined<boolean>(
+      this.settings.isTodosPanelVisible,
+      DEFAULT_TODOS_VISIBLE,
+    );
   }
 
   @computed get isFeatureEnabledByUser() {

--- a/src/jsUtils.ts
+++ b/src/jsUtils.ts
@@ -1,19 +1,7 @@
-// TODO: ifUndefinedString can be removed after ./src/webview/recipe.js is converted to typescript.
-export const ifUndefinedString = (
-  source: string | undefined | null,
-  defaultValue: string,
-): string => (source !== undefined && source !== null ? source : defaultValue);
-
 export const ifUndefined = <T>(
   source: undefined | null | T,
   defaultValue: T,
-): T => {
-  if (source !== undefined && source !== null) {
-    return source;
-  }
-
-  return defaultValue;
-};
+): T => (source !== undefined && source !== null ? source : defaultValue);
 
 export const convertToJSON = (data: string | any | undefined | null) =>
   data && typeof data === 'string' && data.length > 0 ? JSON.parse(data) : data;

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -44,7 +44,7 @@ import {
 } from './spellchecker';
 
 import { DEFAULT_APP_SETTINGS } from '../config';
-import { ifUndefinedString } from '../jsUtils';
+import { ifUndefined } from '../jsUtils';
 import { AppStore } from '../@types/stores.types';
 import Service from '../models/Service';
 
@@ -170,7 +170,7 @@ class RecipeController {
   }
 
   @computed get spellcheckerLanguage() {
-    return ifUndefinedString(
+    return ifUndefined<string>(
       this.settings.service.spellcheckerLanguage,
       this.settings.app.spellcheckerLanguage,
     );

--- a/test/jsUtils.test.ts
+++ b/test/jsUtils.test.ts
@@ -1,23 +1,6 @@
 import * as jsUtils from '../src/jsUtils';
 
 describe('jsUtils', () => {
-  describe('ifUndefinedString', () => {
-    it('returns the default value for undefined input', () => {
-      const result = jsUtils.ifUndefinedString(undefined, 'abc');
-      expect(result).toEqual('abc');
-    });
-
-    it('returns the default value for null input', () => {
-      const result = jsUtils.ifUndefinedString(null, 'abc');
-      expect(result).toEqual('abc');
-    });
-
-    it('returns the non-default input value for regular string input', () => {
-      const result = jsUtils.ifUndefinedString('some random string', 'abc');
-      expect(result).toEqual('some random string');
-    });
-  });
-
   describe('ifUndefined<string>', () => {
     it('returns the default value for undefined input', () => {
       const result = jsUtils.ifUndefined<string>(undefined, 'abc');


### PR DESCRIPTION
After the changes to the Toggle component the Default values aren't displayed correctly. The `default` field does not seem to be respected since the upgrade. Decided to add the default to the value property when the value is otherwise undefined. 
