### PR TITLE
chore: update SECURITY.md to display correct version

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.5.0   | :white_check_mark: |
-| 5.4.3   | :x:                |
-| < 5.4.3 | :x:                |
+| > 6.*   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Updated the SECURITY.md, the current version displays previous Ferdi versions. Modified to show we support the 6.* version range.