### PR TITLE
Use dependabot to help fixing vulnerable dependencies and improve security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Hello developers
The use of dependabot is free for public projects/repositories.

It will help you to maintain many of your dependencies up to date resulting on a more secure application.

You need to enable some options on the repo configuration after adding this file.
(Settings -> Code security -> enable top 5 options)

At this moment, dependabot is able to create 5 PullRequests were he is suggestion you to bump some versions such as:

- eslint-plugin-jsx-a11y from 6.6.1 to 6.7.1
- eslint-plugin-import from 2.26.0 to 2.27.4
- wait-on from 6.0.1 to 7.0.1
- node-fetch from 2.6.7 to 3.3.0
- ws from 8.11.0 to 8.12.0

Also, Dependabot is alerting about 4 different vulnerabilities regarding jsonwebtoken.
The version in use is vulnerable for some different things where the highest CVSS (Common Vulnerability Scoring System) score is 7.5 and the lowest is still to be determined.