### PR TITLE
Shorten desktop entry comment field

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,7 +90,7 @@ linux:
   executableName: ferdium
   synopsis: "Messaging app for WhatsApp, Slack, Telegram, Gmail, Hangouts and many many more."
   # Note: Please keep the description as a single-line string, as this will become the Comment in the ferdium.desktop Linux launcher file, which requires a single line.
-  description: 'General web application and messaging services combiner'
+  description: 'Desktop app bringing all your messaging services into one installable'
   artifactName: "${productName}-${os}-${version}.${ext}"
   target:
     - target: AppImage

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,7 +90,7 @@ linux:
   executableName: ferdium
   synopsis: "Messaging app for WhatsApp, Slack, Telegram, Gmail, Hangouts and many many more."
   # Note: Please keep the description as a single-line string, as this will become the Comment in the ferdium.desktop Linux launcher file, which requires a single line.
-  description: 'Ferdium is your messaging app / former heir to the throne of Austria-Hungary and combines chat & messaging services into one application. Ferdium currently supports Slack, WhatsApp, Gmail, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more. You can download Ferdium for free for Mac, Windows, and Linux. For enabling webcam access you need to connect "camera" plug to snap, and for microphone with PulseAudio - "audio-record" plug. This can be done in Snap GUI or via command: `snap connect ferdium:camera; snap connect ferdium:audio-record`.'
+  description: 'General web application and messaging services combiner'
   artifactName: "${productName}-${os}-${version}.${ext}"
   target:
     - target: AppImage


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Shortens the desktop entry comment to a more reasonable length.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
The current desktop entry is too long and can not be read properly in standard app launchers. This change closes https://github.com/flathub/org.ferdium.Ferdium/issues/21

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Shorten desktop entry comment field