### PR TITLE
Fix to allow resizing of the todos panel

### DIFF
--- a/src/features/todos/components/TodosWebview.tsx
+++ b/src/features/todos/components/TodosWebview.tsx
@@ -106,7 +106,7 @@ class TodosWebview extends Component<IProps, IState> {
     });
   };
 
-  resizePanel(e: MouseEventInit): void {
+  resizePanel = (e: MouseEventInit): void => {
     const { minWidth } = this.props;
     const { isDragging, initialPos } = this.state;
 
@@ -117,9 +117,9 @@ class TodosWebview extends Component<IProps, IState> {
         delta,
       });
     }
-  }
+  };
 
-  stopResize(): void {
+  stopResize = (): void => {
     const { resize, minWidth } = this.props;
     const { isDragging, delta, width } = this.state;
 
@@ -138,9 +138,9 @@ class TodosWebview extends Component<IProps, IState> {
 
       resize(newWidth);
     }
-  }
+  };
 
-  startListeningToIpcMessages() {
+  startListeningToIpcMessages = (): void => {
     if (!this.webview) {
       return;
     }
@@ -149,7 +149,7 @@ class TodosWebview extends Component<IProps, IState> {
     this.webview.addEventListener('ipc-message', e => {
       handleClientMessage(e.channel, e.args[0]);
     });
-  }
+  };
 
   render(): ReactElement {
     const {

--- a/src/features/todos/components/TodosWebview.tsx
+++ b/src/features/todos/components/TodosWebview.tsx
@@ -98,13 +98,13 @@ class TodosWebview extends Component<IProps, IState> {
     }
   }
 
-  startResize(e: MouseEvent<HTMLDivElement>): void {
+  startResize = (e: MouseEvent<HTMLDivElement>): void => {
     this.setState({
       isDragging: true,
       initialPos: e.clientX,
       delta: 0,
     });
-  }
+  };
 
   resizePanel(e: MouseEventInit): void {
     const { minWidth } = this.props;


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

In the file `src/features/todos/components/TodosWebview.tsx`, in the method `startResize` of the class `TodosWebview`, `this` is bound to `undefined`, so the method doesn’t work because the property `setState` of `undefined` doesn’t exist. This prevents one from resizing the todos panel.

Note 1: I made the minimal changes required to fix the issue. I don’t know if the other methods should be changed as well for code consistency or anything.

Note 2: For further details about this issue and another way to solve it, see [this article](https://bobbyhadz.com/blog/react-typeerror-cannot-read-property-setstate-of-undefined).

#### Motivation and Context

It fixes #1107 

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

Fixed todos sidebar resizing