### PR TITLE
chore: silence deprecated version and unmet peer dependency warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
 save-exact = true
 engine-strict = true
 unsafe-perm = true
-legacy-peer-deps = true
-frozen-lockfile = false
+strict-peer-dependencies=true

--- a/package.json
+++ b/package.json
@@ -185,6 +185,30 @@
   "pnpm": {
     "overrides": {
       "usocket": "_EXCLUDED_"
+    },
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "esbuild-sass-plugin>esbuild": "^0.16.7",
+        "react-electron-web-view>react": "^18.0.0",
+        "react-electron-web-view>react-dom": "^18.0.0",
+        "react-loader>react": "^18.0.0",
+        "react-loader>react-dom": "^18.0.0",
+        "react-sortable-hoc>react": "^18.0.0",
+        "react-sortable-hoc>react-dom": "^18.0.0"
+      }
+    },
+    "allowedDeprecatedVersions": {
+      "kleur": "2.0.2",
+      "set-value": "1.0.0",
+      "request": "2.88.2",
+      "har-validator": "5.1.5",
+      "uuid": "3.4.0",
+      "@sinonjs/fake-timers": "10.2.0",
+      "@npmcli/move-file": "1.1.2 || 2.0.1",
+      "source-map-resolve": "0.5.3",
+      "source-map-url": "0.4.1",
+      "resolve-url": "0.2.1",
+      "urix": "0.1.0"
     }
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5378,7 +5378,7 @@ packages:
   /esbuild-sass-plugin@2.10.0(esbuild@0.16.17):
     resolution: {integrity: sha512-STv849QGT8g77RRFmroSt4VBVKjv+dypKcO4aWz8IP4G5JbRH0KC0+B8ODuzlUNu9R5MbkGcev/62RDP/JcZ2Q==}
     peerDependencies:
-      esbuild: ^0.18.0
+      esbuild: ^0.18.0 || ^0.16.7
     dependencies:
       esbuild: 0.16.17
       resolve: 1.22.2
@@ -10404,8 +10404,8 @@ packages:
   /react-electron-web-view@2.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-C/mrvzvLzu/2j/ZFXkv1INNs7Sxv4EmySnAG/L24NRM8zW2Ij0aIbr0rNSLpg43RlAESKfM6TklMZu/UqPDFaA==}
     peerDependencies:
-      react: ^15.0.0
-      react-dom: ^15.0.0
+      react: ^15.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^18.0.0
     dependencies:
       lodash.camelcase: 4.3.0
       react: 18.2.0
@@ -10468,8 +10468,8 @@ packages:
   /react-loader@2.4.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pNW5xoSt0Q7HdmQh/EaIeeFbG0Ii74y6Le8gPdDyWyEFNgCiY1NcreQxMioQGjQ4Jo4EenQGKN/qMbxW+dpZkQ==}
     peerDependencies:
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0
-      react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^18.0.0
+      react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^18.0.0
     dependencies:
       create-react-class: 15.7.0
       prop-types: 15.8.1
@@ -10520,8 +10520,8 @@ packages:
     resolution: {integrity: sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==}
     peerDependencies:
       prop-types: ^15.5.7
-      react: ^16.3.0 || ^17.0.0
-      react-dom: ^16.3.0 || ^17.0.0
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.1
       invariant: 2.2.4


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- add logged deprecated dependencies to `pnpm.allowedDeprecatedVersions`
- configure unmet peer dependencies in `pnpm.peerDependencyRules.allowedVersions`
- update used flags in `.npmrc`

#### Motivation and Context
Warning logs for deprecated dependencies are popping up on every pnpm install and can be distracting for developers. Instead, now they are silenced and whenever specific dependencies are upgraded, it can be checked if entries from `pnpm.allowedDeprecatedVersions` can be removed. Pretty much the same is true for dependencies in `pnpm.peerDependencyRules.allowedVersions`

#### Screenshots
Before, unmet peer dependency warnings were ignored because they were throwing a warning instead of error only
![Screenshot from 2023-07-24 12-56-26](https://github.com/ferdium/ferdium-app/assets/16797721/7d5d1725-9a98-4a94-9e38-2db22e91665b)

After, no more peer dependency warnings and they would lead to exit code 1

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
