### PR TITLE
ci: modernize github actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -309,7 +309,7 @@ jobs:
     name: 'windows ${{ github.event.inputs.message }}'
     needs: check_updates
     if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Windows]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Set env vars
         run: |
@@ -356,10 +356,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      # TODO: Remove this once https://github.com/electron-userland/electron-builder/issues/6933#issuecomment-1213438889 is resolved
-      - name: Tweak pnpm.cjs
-        run: sed -i 's/\/usr\/bin\/env node/node/g' /c/npm/prefix/node_modules/pnpm/bin/pnpm.cjs
-        shell: bash
       - name: Install node dependencies
         uses: nick-fields/retry@v2.8.3
         with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -309,7 +309,7 @@ jobs:
     name: 'windows ${{ github.event.inputs.message }}'
     needs: check_updates
     if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Windows]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - name: Set env vars
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       message:
-        description: "Message for build"
+        description: 'Message for build'
         required: true
   schedule:
     - cron: '0 0 * * *' # every night at 12 am
@@ -34,8 +34,8 @@ env:
 
 jobs:
   check_updates:
-    runs-on: ubuntu-20.04
-    name: "Check latest commit: ${{ github.event.inputs.message }}"
+    runs-on: ubuntu-22.04
+    name: 'Check latest commit: ${{ github.event.inputs.message }}'
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
@@ -46,17 +46,18 @@ jobs:
           ref: nightly
           submodules: recursive
           fetch-depth: 0 # Note: Needed to be able to pull the 'develop' branch as well for merging
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
         with:
-          node-version-file: ".nvmrc"
-      - name: Install pnpm
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
-        run: npm i -gf "pnpm@$(node -p 'require("./package.json").engines.pnpm')" && pnpm -v
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - name: Install node dependencies
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@v2.8.3
         with:
           command: pnpm i
           timeout_minutes: 15
@@ -128,7 +129,7 @@ jobs:
           fi
 
   build_mac:
-    name: "macos ${{ github.event.inputs.message }}"
+    name: 'macos ${{ github.event.inputs.message }}'
     needs: check_updates
     if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[macOS]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
     runs-on: macos-12
@@ -136,7 +137,6 @@ jobs:
       - name: Set env vars
         run: |
           echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
-          echo "PNPM_CACHE=$HOME/.pnpm-store" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
@@ -161,23 +161,24 @@ jobs:
         env:
           cache-name: cache-electron-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_CACHE }}
       - name: Cache electron-builder modules
         uses: actions/cache@v3
         env:
           cache-name: cache-electron-builder-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
-      - name: Install pnpm
-        run: npm i -gf "pnpm@$(node -p 'require("./package.json").engines.pnpm')" && pnpm -v
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - name: Install node dependencies
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@v2.8.3
         with:
           command: pnpm i
           timeout_minutes: 15
@@ -207,15 +208,14 @@ jobs:
         shell: bash
 
   build_linux:
-    name: "ubuntu ${{ github.event.inputs.message }}"
+    name: 'ubuntu ${{ github.event.inputs.message }}'
     needs: check_updates
     if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Linux]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set env vars
         run: |
           echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
-          echo "PNPM_CACHE=$HOME/.pnpm-store" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
@@ -240,23 +240,24 @@ jobs:
         env:
           cache-name: cache-electron-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_CACHE }}
       - name: Cache electron-builder modules
         uses: actions/cache@v3
         env:
           cache-name: cache-electron-builder-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
-      - name: Install pnpm
-        run: npm i -gf "pnpm@$(node -p 'require("./package.json").engines.pnpm')" && pnpm -v
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - name: Install node dependencies
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@v2.8.3
         with:
           command: pnpm i
           timeout_minutes: 15
@@ -305,16 +306,15 @@ jobs:
         shell: bash
 
   build_windows:
-    name: "windows ${{ github.event.inputs.message }}"
+    name: 'windows ${{ github.event.inputs.message }}'
     needs: check_updates
     if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Windows]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Set env vars
         run: |
           echo "HOME=$USERPROFILE" >> $GITHUB_ENV
           echo "NPM_CACHE=$USERPROFILE/.npm" >> $GITHUB_ENV
-          echo "PNPM_CACHE=$USERPROFILE/.pnpm-store" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$USERPROFILE/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$USERPROFILE/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
@@ -340,27 +340,28 @@ jobs:
         env:
           cache-name: cache-electron-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_CACHE }}
       - name: Cache electron-builder modules
         uses: actions/cache@v3
         env:
           cache-name: cache-electron-builder-modules
         with:
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pnpm-lock.yaml') }}
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
-      - name: Install pnpm
-        run: npm i -gf "pnpm@$(node -p 'require(\"./package.json\").engines.pnpm')" && pnpm -v
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       # TODO: Remove this once https://github.com/electron-userland/electron-builder/issues/6933#issuecomment-1213438889 is resolved
       - name: Tweak pnpm.cjs
         run: sed -i 's/\/usr\/bin\/env node/node/g' /c/npm/prefix/node_modules/pnpm/bin/pnpm.cjs
         shell: bash
       - name: Install node dependencies
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@v2.8.3
         with:
           command: pnpm i
           timeout_minutes: 15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,9 @@ git checkout nightly && git pull -r
 git checkout release
 git merge --no-ff nightly --no-verify
 # <manually resolve conflicts>
-# <manually bump version with 'beta' name (if beta) in `package.json` and `package-lock.json`>
+# <manually bump version with 'beta' name (if beta) in `package.json`>
+# <run the build script for your OS from the `scripts` folder>
+# <add all pertinent changes to git>
 # <create commit>
 # <create tag>
 git push

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": "18.15.0",
     "pnpm": "8.6.2"
   },
+  "packageManager": "pnpm@8.6.2",
   "scripts": {
     "prepare": "is-ci || husky install",
     "start": "electron ./build",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- use `ubuntu-22.04` runner instead of `ubuntu-20.04`
- use `windows-2022` runner instead of `windows-2019`
- use `pnpm/action-setup` instead of handling `pnpm install` manually
- use `pnpm-lock.yaml` as caching key for `actions/cache` instead of inexistent `package-lock.json`
- define `packageManager` config option in `package.json` which is read by `pnpm/action-setup`

#### Motivation and Context
Switch to the latest GitHub-hosted runners based on: https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#choosing-github-hosted-runners

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
