### PR TITLE
feat: picture in picture availability for video players

### DIFF
--- a/src/webview/contextMenuBuilder.ts
+++ b/src/webview/contextMenuBuilder.ts
@@ -249,6 +249,10 @@ export class ContextMenuBuilder {
       return this.buildMenuForImage(info);
     }
 
+    if (info.mediaType === 'video') {
+      return this.buildMenuForVideo(info);
+    }
+
     if (
       info.isEditable ||
       (info.inputFieldType && info.inputFieldType !== 'none')
@@ -402,6 +406,40 @@ export class ContextMenuBuilder {
     this.addInspectElement(menu, menuInfo);
     // @ts-expect-error Expected 1 arguments, but got 2.
     this.processMenu(menu, menuInfo);
+
+    return menu;
+  }
+
+  /**
+   * Builds a menu applicable to a video.
+   *
+   * @return {Menu}  The `Menu`
+   */
+  buildMenuForVideo(
+    menuInfo: IContextMenuParams,
+  ): Electron.CrossProcessExports.Menu {
+    const menu = new Menu();
+    const video = document.querySelectorAll('video')[0];
+
+    if (
+      document.pictureInPictureEnabled &&
+      !video.disablePictureInPicture &&
+      this.isSrcUrlValid(menuInfo)
+    ) {
+      menu.append(
+        new MenuItem({
+          type: 'checkbox',
+          label: 'Picture in picture',
+          enabled: true,
+          checked: !!document.pictureInPictureElement,
+          click: async () => {
+            await (document.pictureInPictureElement
+              ? document.exitPictureInPicture()
+              : video.requestPictureInPicture());
+          },
+        }),
+      );
+    }
 
     return menu;
   }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- add `buildMenuForVideo` method in `contextMenuBuilder.ts`
- add picture in picture context menu entry which toggles picture in picture mode if right-clicked node is video

***

Implemented this feature based on the example on: https://w3c.github.io/picture-in-picture/#example-add-custom-pip-button

#### Motivation and Context

Closes https://github.com/ferdium/ferdium-app/issues/1181

#### Screenshots

I made sure that the picture in picture mode functionality behaves the same as in a browser (double right-click to show it, and it shows up with checkmark if its enabled):

[Screencast from 2023-07-26 08-40-12.webm](https://github.com/ferdium/ferdium-app/assets/16797721/fc26f8f2-35bb-44bc-b334-4e7a83911112)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
