### PR TITLE
chore: upgrade mobx-react-form to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mobx": "6.10.0",
     "mobx-localstorage": "1.2.0",
     "mobx-react": "7.6.0",
-    "mobx-react-form": "3.2.0",
+    "mobx-react-form": "6.3.5",
     "moment": "2.29.4",
     "ms": "2.1.3",
     "node-fetch": "2.6.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ dependencies:
     specifier: 7.6.0
     version: 7.6.0(mobx@6.10.0)(react-dom@18.2.0)(react@18.2.0)
   mobx-react-form:
-    specifier: 3.2.0
-    version: 3.2.0(mobx@6.10.0)
+    specifier: 6.3.5
+    version: 6.3.5(mobx@6.10.0)
   moment:
     specifier: 2.29.4
     version: 2.29.4
@@ -9096,8 +9096,8 @@ packages:
       reactive-localstorage: 0.0.2
     dev: false
 
-  /mobx-react-form@3.2.0(mobx@6.10.0):
-    resolution: {integrity: sha512-7ddOvBulXW5VSMpxrok0A1VGZuWgn1cSvQ2HFXK2uMg631/37Anck7ASWEqK3AzKOaaP9/0kr7VCChqvhyotzQ==}
+  /mobx-react-form@6.3.5(mobx@6.10.0):
+    resolution: {integrity: sha512-AsnfL1MC9Jm2wcF6hr7ayZjmqwrYw37LHMRFcjvXkmCSFEXM0/qKPA3/Ex3TOL4gmCEoBVoV/XhhfIuj5csUgQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       mobx: ^6.0.0

--- a/src/@types/mobx-react-form.d.ts
+++ b/src/@types/mobx-react-form.d.ts
@@ -1,1 +1,0 @@
-declare module 'mobx-react-form';

--- a/src/components/auth/Invite.tsx
+++ b/src/components/auth/Invite.tsx
@@ -86,8 +86,7 @@ class Invite extends Component<IProps, IState> {
               },
             },
           }),
-          // TODO: [TS DEBT] need to fix this type once mobx-react-form is updated to next version
-        ] as any,
+        ],
       },
     });
   }

--- a/src/components/ui/Radio.tsx
+++ b/src/components/ui/Radio.tsx
@@ -1,10 +1,11 @@
 import { Component } from 'react';
 import { observer } from 'mobx-react';
-import { Field } from 'mobx-react-form';
 import classnames from 'classnames';
+import FieldInterface from 'mobx-react-form/lib/models/FieldInterface';
+import Error from './error';
 
 type Props = {
-  field: typeof Field;
+  field: FieldInterface;
   className: string;
   focus: boolean;
   showLabel: boolean;
@@ -47,7 +48,8 @@ class Radio extends Component<Props> {
           </label>
         )}
         <div className="franz-form__radio-wrapper">
-          {field.options.map(type => (
+          {/* @ts-expect-error Property 'map' does not exist on type 'OptionsModel'. */}
+          {field.options?.map(type => (
             <label
               key={type.value}
               htmlFor={`${field.id}-${type.value}`}
@@ -68,7 +70,8 @@ class Radio extends Component<Props> {
             </label>
           ))}
         </div>
-        {field.error && <div className="franz-form__error">{field.error}</div>}
+
+        {field.error && <Error message={field.error} />}
       </div>
     );
   }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- upgrade `mobx-react-form` from v3 to v6
- remove stub `mobx-react-form.d.ts` since the dependency is written in TS now
- remove `as any` cast for `new Form` invocation in `invite.tsx`
- reuse `Error` component in `Radio.tsx` to get validation error message in red
- use `FieldInterface` type for `field` property instead of `typeof Field` in `Radio.tsx`

#### Motivation and Context
The dependency was a couple of major versions behind, luckily the upgrade path was quite easy. The new major versions all seem to have to do with the library adopting TypeScript:
https://github.com/foxhound87/mobx-react-form/releases/tag/v4.0.0
https://github.com/foxhound87/mobx-react-form/releases/tag/v5.0.0
https://github.com/foxhound87/mobx-react-form/releases/tag/v6.0.0

#### Screenshots

`Form` and `Radio` components which are using `mobx-react-form` are still working as expected:

[Screencast from 2023-07-26 19-56-59.webm](https://github.com/ferdium/ferdium-app/assets/16797721/6aaf3a9d-fdf0-466f-a550-01759610c50f)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
