### PR TITLE
workaround: notifications not displaying for WhatsApp

### DIFF
--- a/src/webview/notifications.ts
+++ b/src/webview/notifications.ts
@@ -46,7 +46,7 @@ export const notificationsClassDefinition = `(() => {
           });
       } catch(error) {
 	        this.options.onClick = null;
-          window.ferdium.displayNotification(this.title, this.options)
+          window.ferdium.displayNotification(title, options)
             .then(() => {
               if (typeof (this.onClick) === 'function') {
                 this.onClick();

--- a/src/webview/notifications.ts
+++ b/src/webview/notifications.ts
@@ -37,12 +37,22 @@ export const notificationsClassDefinition = `(() => {
     constructor(title = '', options = {}) {
       this.title = title;
       this.options = options;
-      window.ferdium.displayNotification(title, options)
-        .then(() => {
-          if (typeof (this.onClick) === 'function') {
-            this.onClick();
-          }
-        });
+      try{
+        window.ferdium.displayNotification(title, options)
+          .then(() => {
+            if (typeof (this.onClick) === 'function') {
+              this.onClick();
+            }
+          });
+      } catch(error) {
+	        this.options.onClick = null;
+          window.ferdium.displayNotification(this.title, this.options)
+            .then(() => {
+              if (typeof (this.onClick) === 'function') {
+                this.onClick();
+              }
+            });      
+      }
     }
 
     static requestPermission(cb = null) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Added try/catch for displaying notifications, with notification options object setting onClick to null in the event of error.  Fixes lack of notifications for WhatsApp (and possibly others) due to failure to clone the options object while displaying notifications (related to onClick function).  This is a workaround until the full problem is resolved, as the change allows notifications to be displayed but when clicking them you are not taken to the proper screen (due to null'ing the onClick function).  This is much better than not receiving any notifications while waiting for a full fix, IMO.

#### Motivation and Context
Workaround/Fix for https://github.com/ferdium/ferdium-app/issues/1105 - WhatsApp notifications are not being displayed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

Workaround for notifications not displaying for some apps (WhatsApp + more).
