### PR TITLE
Update macos-notification-state for patched v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "usocket": "_EXCLUDED_"
   },
   "optionalDependencies": {
-    "macos-notification-state": "github:ferdium/macos-notification-state#130bb2602795b65ae2dea74d823027b185eaf0ae",
+    "macos-notification-state": "github:ferdium/macos-notification-state#e0465373b0aed12ea4ce30522e82aaa8706cdf40",
     "node-mac-permissions": "2.3.0"
   },
   "browserslist": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,8 +263,8 @@ dependencies:
 
 optionalDependencies:
   macos-notification-state:
-    specifier: github:ferdium/macos-notification-state#130bb2602795b65ae2dea74d823027b185eaf0ae
-    version: github.com/ferdium/macos-notification-state/130bb2602795b65ae2dea74d823027b185eaf0ae
+    specifier: github:ferdium/macos-notification-state#e0465373b0aed12ea4ce30522e82aaa8706cdf40
+    version: github.com/ferdium/macos-notification-state/e0465373b0aed12ea4ce30522e82aaa8706cdf40
   node-mac-permissions:
     specifier: 2.3.0
     version: 2.3.0
@@ -10043,6 +10043,12 @@ packages:
     dev: true
     optional: true
 
+  /node-addon-api@3.0.0:
+    resolution: {integrity: sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /node-addon-api@3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
     requiresBuild: true
@@ -13793,12 +13799,13 @@ packages:
       stack-trace: 0.0.10
     dev: false
 
-  github.com/ferdium/macos-notification-state/130bb2602795b65ae2dea74d823027b185eaf0ae:
-    resolution: {tarball: https://codeload.github.com/ferdium/macos-notification-state/tar.gz/130bb2602795b65ae2dea74d823027b185eaf0ae}
+  github.com/ferdium/macos-notification-state/e0465373b0aed12ea4ce30522e82aaa8706cdf40:
+    resolution: {tarball: https://codeload.github.com/ferdium/macos-notification-state/tar.gz/e0465373b0aed12ea4ce30522e82aaa8706cdf40}
     name: macos-notification-state
-    version: 2.0.2
+    version: 3.0.0
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
+      node-addon-api: 3.0.0
     dev: false
     optional: true

--- a/src/electron/ipc-api/dnd.ts
+++ b/src/electron/ipc-api/dnd.ts
@@ -17,7 +17,7 @@ export default async () => {
     }
 
     try {
-      const isDND = getDoNotDisturb();
+      const isDND = await getDoNotDisturb();
       debug('Fetching DND state, set to', isDND);
       return isDND;
     } catch (error) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Update the `macos-notification-state` module to use the patched version of `3.0.0` from our fork.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
On Mac, the Focus Mode introduced in MacOS 12 is not working as expected with regards to the notifications. A long standing PR on the original repo has finally been merged and incorporated into our fork, which should fix this problem.
Fix #798.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
