### PR TITLE
fix: login and signup error messages

### DIFF
--- a/src/api/server/ServerApi.ts
+++ b/src/api/server/ServerApi.ts
@@ -62,13 +62,19 @@ export default class ServerApi {
       },
       false,
     );
-    if (!request.ok) {
-      throw new Error(request.statusText);
-    }
-    const u = await request.json();
+    try {
+      const responseJson = await request.json();
 
-    debug('ServerApi::login resolves', u);
-    return u.token;
+      if (!request.ok) {
+        throw responseJson;
+      }
+
+      debug('ServerApi::login resolves', responseJson);
+      return responseJson.token;
+    } catch (error) {
+      debug('ServerApi::login ERROR:', error);
+      throw error;
+    }
   }
 
   async signup(data: any) {
@@ -80,13 +86,19 @@ export default class ServerApi {
       },
       false,
     );
-    if (!request.ok) {
-      throw new Error(request.statusText);
-    }
-    const u = await request.json();
+    try {
+      const responseJson = await request.json();
 
-    debug('ServerApi::signup resolves', u);
-    return u.token;
+      if (!request.ok) {
+        throw responseJson;
+      }
+
+      debug('ServerApi::signup resolves', responseJson);
+      return responseJson.token;
+    } catch (error) {
+      debug('ServerApi::signup ERROR:', error);
+      throw error;
+    }
   }
 
   async inviteUser(data: any) {

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -139,26 +139,30 @@ class Login extends Component<IProps> {
           <Input {...form.$('password').bind()} showPasswordToggle />
           {error.code === 'invalid-credentials' && (
             <>
-              <p className="error-message center">
+              <h2 className="error-message center">
                 {intl.formatMessage(messages.invalidCredentials)}
-              </p>
+              </h2>
               {window['ferdium'].stores.settings.all.app.server !==
                 LIVE_FRANZ_API && (
-                <p className="error-message center">
-                  {intl.formatMessage(messages.customServerQuestion)}{' '}
-                  <Link
-                    to={`${window[
-                      'ferdium'
-                    ].stores.settings.all.app.server.replace(
-                      API_VERSION,
-                      '',
-                    )}/import`}
-                    target="_blank"
-                    style={{ cursor: 'pointer', textDecoration: 'underline' }}
-                  >
-                    {intl.formatMessage(messages.customServerSuggestion)}
-                  </Link>
-                </p>
+                <>
+                  <p className="error-message center">
+                    {intl.formatMessage(messages.customServerQuestion)}{' '}
+                  </p>
+                  <p className="error-message center">
+                    <Link
+                      to={`${window[
+                        'ferdium'
+                      ].stores.settings.all.app.server.replace(
+                        API_VERSION,
+                        '',
+                      )}/import`}
+                      target="_blank"
+                      style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                    >
+                      {intl.formatMessage(messages.customServerSuggestion)}
+                    </Link>
+                  </p>
+                </>
               )}
             </>
           )}

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -148,10 +148,10 @@ class Signup extends Component<IProps> {
               showPasswordToggle
               scorePassword
             />
-            {error.code === 'email-duplicate' && (
-              <p className="error-message center">
+            {error.status === 401 && (
+              <h2 className="error-message center">
                 {intl.formatMessage(messages.emailDuplicate)}
-              </p>
+              </h2>
             )}
             {isSubmitting ? (
               <Button


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Fix error messages not showing on login/signup pages

#### Motivation and Context
When the user tried to login or signup, no error message was displayed when there was some error on the server side. This PR should handle the known errors (invalid/duplicate email or wrong password).

Fixes https://github.com/ferdium/ferdium-app/issues/312
Possibly addresses https://github.com/ferdium/ferdium-app/issues/1082

#### Screenshots
| Signup | Login |
|-- |-- |
| ![image](https://github.com/ferdium/ferdium-app/assets/37463445/f2eddd65-10b9-4f48-b3c4-e28536745d36) | ![image](https://github.com/ferdium/ferdium-app/assets/37463445/0d6bd9fc-0b02-42d3-a436-6d1448123101) |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fix error messages not showing on login/signup pages