### PR TITLE
electron-builder: Run snap as native wayland client unless specified

### DIFF
--- a/build-helpers/snap-hooks/configure
+++ b/build-helpers/snap-hooks/configure
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+wayland_native="$(snapctl get wayland-native)"
+if [[ -z "$wayland_native" ]]; then
+    snapctl set wayland-native=true
+fi

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,6 +10,8 @@ publish:
 snap:
   plugs: ["default", "camera", "audio-record", "removable-media"]
   allowNativeWayland: true
+  executableArgs: ["$(sh -c '[ \"$(snapctl get wayland-native)\" != \"false\" ] && echo --ozone-platform-hint=auto || true')"]
+  hooks: ./build-helpers/snap-hooks
   publish:
     provider: snapStore
   description: 'Ferdium is your cross-platform messaging app / former heir to the throne of Austria-Hungary which brings your chat & messaging services together into one application. For enabling webcam access you need to connect "camera" plug to snap, and for microphone with PulseAudio the "audio-record" plug. This can be done in Snap GUI or via command: `snap connect ferdium:camera; snap connect ferdium:audio-record`.'


### PR DESCRIPTION
Make ferdium to run as native wayland client if possible, adding configuration hook to make possible to toggle this feature.

Users can use `snap set ferdium wayland-native=false` to use XWayland client instead.

This is relevant especially when using native scaling, as visible in:

![Schermata del 2023-11-26 14-32-41](https://github.com/ferdium/ferdium-app/assets/345675/a7cb853c-ab4e-42b6-9ece-67bf048fc138)

Before:

![Schermata del 2023-11-26 14-32-05](https://github.com/ferdium/ferdium-app/assets/345675/c4c8838b-6288-4632-a20b-eb67867f2e38)

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

Run snap as native wayland client unless configured otherwise