### PR TITLE
Rudimentary DBus toggle-to-talk support

### DIFF
--- a/docs/dbus/org.ferdium.Ferdium.xml
+++ b/docs/dbus/org.ferdium.Ferdium.xml
@@ -38,6 +38,13 @@
     -->
     <method name="ToggleWindow" />
     <!--
+      ToggleToTalk:
+
+      Toggles the microphone in the active service if supported and currently
+      applicable.
+    -->
+    <method name="ToggleToTalk" />
+    <!--
       Muted:
 
       Gets or sets the current muted state of notifications.

--- a/src/lib/dbus/Ferdium.ts
+++ b/src/lib/dbus/Ferdium.ts
@@ -31,6 +31,10 @@ export default class Ferdium extends dbus.interface.Interface {
     this.dbus.trayIcon._toggleWindow();
   }
 
+  ToggleToTalk(): void {
+    this.dbus.trayIcon.mainWindow?.webContents.send('toggle-to-talk');
+  }
+
   emitUnreadChanged(): void {
     Ferdium.emitPropertiesChanged(
       this,
@@ -63,6 +67,10 @@ Ferdium.configureMembers({
       outSignature: '',
     },
     ToggleWindow: {
+      inSignature: '',
+      outSignature: '',
+    },
+    ToggleToTalk: {
       inSignature: '',
       outSignature: '',
     },

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -641,4 +641,8 @@ export default class Service {
     this.unreadDirectMessageCount = 0;
     this.unreadIndirectMessageCount = 0;
   }
+
+  toggleToTalk(): void {
+    this.webview?.send('toggle-to-talk');
+  }
 }

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -65,6 +65,8 @@ export default class ServicesStore extends TypedStore {
   // No service ID should be in the list multiple times, not all service IDs have to be in the list
   @observable lastUsedServices: string[] = [];
 
+  private toggleToTalkCallback = () => this.active?.toggleToTalk();
+
   constructor(stores: Stores, api: ApiInterface, actions: Actions) {
     super(stores, api, actions);
 
@@ -239,12 +241,16 @@ export default class ServicesStore extends TypedStore {
   initialize() {
     super.initialize();
 
+    ipcRenderer.on('toggle-to-talk', this.toggleToTalkCallback);
+
     // Check services to become hibernated
     this.serviceMaintenanceTick();
   }
 
   teardown() {
     super.teardown();
+
+    ipcRenderer.off('toggle-to-talk', this.toggleToTalkCallback);
 
     // Stop checking services for hibernation
     this.serviceMaintenanceTick.cancel();

--- a/src/webview/lib/RecipeWebview.ts
+++ b/src/webview/lib/RecipeWebview.ts
@@ -40,6 +40,8 @@ class RecipeWebview {
 
   loopFunc = () => null;
 
+  toggleToTalkFunc = () => null;
+
   darkModeHandler: ((darkMode: boolean, config: any) => void) | null = null;
 
   // TODO Remove this once we implement a proper wrapper.
@@ -198,6 +200,10 @@ class RecipeWebview {
 
   openNewWindow(url) {
     ipcRenderer.sendToHost('new-window', url);
+  }
+
+  toggleToTalk(fn) {
+    this.toggleToTalkFunc = fn;
   }
 }
 

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -158,6 +158,7 @@ class RecipeController {
     'service-settings-update': 'updateServiceSettings',
     'get-service-id': 'serviceIdEcho',
     'find-in-page': 'openFindInPage',
+    'toggle-to-talk': 'toggleToTalk',
   };
 
   universalDarkModeInjected = false;
@@ -482,6 +483,10 @@ class RecipeController {
         }
       }, 225),
     );
+  }
+
+  toggleToTalk() {
+    this.recipe?.toggleToTalkFunc?.();
   }
 }
 


### PR DESCRIPTION


<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Adds a ToggleToTalk method to the DBus interface to unmute/mute the microphone in the active service if the recipe supports it.

We will need to add support for this feature in recipes.

#### Motivation and Context
Unmuting and muting the microphone by going into the application window can be tedious (e.g., while screen sharing during a meeting or while gaming), even if common courtesy dictates not running with an open mic in a noisy environment. A common solution for this is applications with global shortcuts that intercept a given keypress either as a push-to-talk (kept held while talking) or toggle-to-talk button.

Unfortunately, the security model of Wayland compositors on Linux disallows applications from intercepting global key presses. A common solution is to configure the key binding right in the compositor (which has the appropriate privileges to intercept it), and talk to the application over IPC. Since we already use DBus as IPC on Linux, this patch adds a new method to the DBus interface to support toggle-to-talk.

For example, this shell script can send a toggle-to-talk method call to Ferdium:

```bash
#!/usr/bin/env bash
exec dbus-send --session --dest=org.ferdium.Ferdium --type=method_call /org/ferdium org.ferdium.Ferdium.ToggleToTalk
```

I have bound it in the [sway](https://github.com/swaywm/sway) compositor like this:

```
bindsym $mod+z exec ~/.local/bin/toggle-to-talk.sh
```

Of course, this feature requires recipe support to appropriately handle the toggle-to-talk event. I deliberately went with a very basic solution to avoid managing mic state: on a toggle-to-talk method call, the active service is asked to toggle its mic. This means that if you switch away from a service during a call, it will no longer receive the toggle-to-talk events. However, the contrary (enable toggle-to-talk even for services in the background) would require us to track which call(s) are currently active, which would be a much more complicated and error-prone solution.

Currently, I haven't patched any recipes to support toggle-to-talk, but this doesn't look like a hard job. For example, Discord seems to work OK with

```javascript
Ferdium.toggleToTalk(() => document.querySelector('button[aria-label="Mute"]')?.click());
```

while Skype requires a slightly more complicated

```javascript
Ferdium.toggleToTalk(() => (document.querySelector('button[aria-label="Unmute"]') ?? document.querySelector('button[aria-label="Mute"]'))?.click());
```

These are all best effort: it might be the case that the mic currently can't be toggled at all. In that case, the toggle-to-talk event is just ignored.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

Added toggle-to-talk support over DBus
