### PR TITLE
chore: fix notification "option" clone

### DIFF
--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -124,8 +124,14 @@ contextBridge.exposeInMainWorld('ferdium', {
     safeParseInt(text),
   setDialogTitle: (title: string | null | undefined) =>
     dialogTitleHandler.setDialogTitle(title),
-  displayNotification: (title: string, options: any) =>
-    notificationsHandler.displayNotification(title, options),
+  displayNotification: (title: string, options: any) => {
+    notificationsHandler.displayNotification(
+      title,
+      // The following line is needed so that a proper clone of the "options" object is made.
+      // This line was causing issues with some services.
+      JSON.parse(JSON.stringify(options)),
+    );
+  },
   getDisplayMediaSelector,
 });
 

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -44,7 +44,7 @@ import {
 } from './spellchecker';
 
 import { DEFAULT_APP_SETTINGS } from '../config';
-import { ifUndefined, safeParseInt } from '../jsUtils';
+import { cleanseJSObject, ifUndefined, safeParseInt } from '../jsUtils';
 import { AppStore } from '../@types/stores.types';
 import Service from '../models/Service';
 
@@ -129,7 +129,7 @@ contextBridge.exposeInMainWorld('ferdium', {
       title,
       // The following line is needed so that a proper clone of the "options" object is made.
       // This line was causing issues with some services.
-      JSON.parse(JSON.stringify(options)),
+      cleanseJSObject(options),
     );
   },
   getDisplayMediaSelector,


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Fix notifications object clone (options)

#### Motivation and Context
Several users are reporting that their services are not showing tray notifications (even though they ear the sound from the service receiving the notification).
After investigating using the Whatsapp service, I was able to see several errors in the console whenever a new notification came in:
![image](https://github.com/ferdium/ferdium-app/assets/37463445/a8708a71-6cf3-449e-9d90-543a5270013b)

This was a hint to investigate what was happening and I came into the conclusion that the `options` object was not being cloned properly (probable because services are injecting some function or keys that are not properly cloned). After doing a "hack" with `JSON.parse` and `JSON.stringify` (we do have this hack in several logic around the app), the `options` object is now properly cloned and doesn't throw any errors - and, therefore, enables users to get the message in the tray at the end.

I tested this with Whatsapp and it worked properly (fixed it actually), but several other services might benefit from this fix.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fixed tray notifications for Whatsapp (and probably other services as well)
