### PR TITLE
chore: upgrade `@electron/notarize` to v2

### DIFF
--- a/build-helpers/notarize.js
+++ b/build-helpers/notarize.js
@@ -11,15 +11,14 @@ exports.default = async function notarizing(context) {
 
   const appName = context.packager.appInfo.productFilename;
 
-  // @ts-ignore global-require
+  // eslint-disable-next-line global-require
   const { notarize } = require('@electron/notarize');
 
   await notarize({
     tool: 'notarytool',
-    appBundleId: 'org.ferdium.ferdium-app',
     appPath: `${appOutDir}/${appName}.app`,
     teamId: '55E9FPJ93P',
-    appleId: process.env.APPLEID,
-    appleIdPassword: process.env.APPLEID_PASSWORD,
+    appleId: process.env.APPLEID || '',
+    appleIdPassword: process.env.APPLEID_PASSWORD || '',
   });
 };

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -70,6 +70,7 @@ mac:
   entitlements: "./build-helpers/entitlements.mas.plist"
   entitlementsInherit: "./build-helpers/entitlements.mas.inherit.plist"
   artifactName: "${productName}-${os}-bundle-${version}-${arch}.${ext}"
+  notarize: false
   target:
     - target: dmg
       arch: [x64, arm64]

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@biomejs/biome": "1.6.1",
     "@commitlint/cli": "19.2.1",
     "@commitlint/config-conventional": "19.1.0",
-    "@electron/notarize": "1.2.3",
+    "@electron/notarize": "2.3.0",
     "@formatjs/cli": "6.2.9",
     "@jest/types": "29.6.3",
     "@types/auto-launch": "5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ devDependencies:
     specifier: 19.1.0
     version: 19.1.0
   '@electron/notarize':
-    specifier: 1.2.3
-    version: 1.2.3
+    specifier: 2.3.0
+    version: 2.3.0
   '@formatjs/cli':
     specifier: 6.2.9
     version: 6.2.9
@@ -1431,18 +1431,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@electron/notarize@1.2.3:
-    resolution: {integrity: sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==}
+  /@electron/notarize@2.2.1:
+    resolution: {integrity: sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 9.1.0
+      promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@electron/notarize@2.2.1:
-    resolution: {integrity: sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==}
+  /@electron/notarize@2.3.0:
+    resolution: {integrity: sha512-EiTBU0BwE7HZZjAG1fFWQaiQpCuPrVGn7jPss1kUjD6eTTdXXd29RiZqEqkgN7xqt/Pgn4g3I7Saqovanrfj3w==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- remove redundant `appBundleId` and provide fallback for `appleId` and `appleIdPassword` in `notarize.js`
- replace `ts-ignore` with `eslint-disable` in `notarize.js`

#### Motivation and Context
Modernize the codebase

I checked https://github.com/electron/notarize/releases/tag/v2.0.0 and the documentation to make sure I do the correct changes.

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
