### PR TITLE
feat: add openProcessManager to View menu

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -124,6 +124,7 @@
   "menu.view.back": "Back",
   "menu.view.forward": "Forward",
   "menu.view.lockFerdium": "Lock Ferdium",
+  "menu.view.openProcessManager": "Open Process Manager",
   "menu.view.openQuickSwitch": "Open Quick Switch",
   "menu.view.reloadFerdium": "Reload Ferdium",
   "menu.view.reloadService": "Reload Service",

--- a/src/lib/Menu.ts
+++ b/src/lib/Menu.ts
@@ -7,6 +7,7 @@ import {
   systemPreferences,
   webContents,
 } from '@electron/remote';
+import { ipcRenderer } from 'electron';
 import { type MenuItemConstructorOptions, clipboard } from 'electron';
 import { fromJS } from 'immutable';
 import { action, autorun, makeObservable, observable } from 'mobx';
@@ -162,6 +163,10 @@ const menuItems = defineMessages({
   toggleServiceDevTools: {
     id: 'menu.view.toggleServiceDevTools',
     defaultMessage: 'Toggle Service Developer Tools',
+  },
+  openProcessManager: {
+    id: 'menu.view.openProcessManager',
+    defaultMessage: 'Open Process Manager',
   },
   reloadService: {
     id: 'menu.view.reloadService',
@@ -762,6 +767,13 @@ class FranzMenu implements StoresProps {
       (tpl[1].submenu as MenuItemConstructorOptions[]).push(
         {
           type: 'separator',
+        },
+        {
+          label: intl.formatMessage(menuItems.openProcessManager),
+          accelerator: `${shiftKey()}+Escape`,
+          click: () => {
+            ipcRenderer.send('openProcessManager');
+          },
         },
         {
           label: intl.formatMessage(menuItems.toggleDevTools),


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Add Open Process Manager option to View menu with `Shift + Escape` shortcut

#### Motivation and Context
This fixes https://github.com/ferdium/ferdium-app/issues/1686

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Add Open Process Manager option to View menu with `Shift + Escape` shortcut