### PR TITLE
feat: use favicons instead of icons

### DIFF
--- a/src/components/settings/services/EditServiceForm.tsx
+++ b/src/components/settings/services/EditServiceForm.tsx
@@ -396,6 +396,7 @@ class EditServiceForm extends Component<IProps, IState> {
 
                 <div className="settings__settings-group">
                   <H3>{intl.formatMessage(messages.headlineAppearance)}</H3>
+                  <Toggle {...form.$('useFavicon').bind()} />
                   <Toggle {...form.$('isDarkModeEnabled').bind()} />
                   {form.$('isDarkModeEnabled').value && (
                     <>

--- a/src/config.ts
+++ b/src/config.ts
@@ -443,6 +443,7 @@ export const DEFAULT_SERVICE_SETTINGS = {
   isBadgeEnabled: true,
   isMediaBadgeEnabled: false,
   trapLinkClicks: false,
+  useFavicon: false,
   isMuted: false,
   customIcon: false,
   isDarkModeEnabled: false,

--- a/src/containers/settings/EditServiceScreen.tsx
+++ b/src/containers/settings/EditServiceScreen.tsx
@@ -96,6 +96,10 @@ const messages = defineMessages({
     id: 'settings.service.form.trapLinkClicks',
     defaultMessage: 'Open URLs within Ferdium',
   },
+  useFavicon: {
+    id: 'settings.service.form.useFavicon',
+    defaultMessage: 'Use service favicon instead of default or custom icon',
+  },
   onlyShowFavoritesInUnreadCount: {
     id: 'settings.service.form.onlyShowFavoritesInUnreadCount',
     defaultMessage: 'Only show Favorites in unread count',
@@ -256,6 +260,15 @@ class EditServiceScreen extends Component<IProps> {
             DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
           ),
           default: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+          type: 'checkbox',
+        },
+        useFavicon: {
+          label: intl.formatMessage(messages.useFavicon),
+          value: ifUndefined<boolean>(
+            service?.useFavicon,
+            DEFAULT_SERVICE_SETTINGS.useFavicon,
+          ),
+          default: DEFAULT_SERVICE_SETTINGS.useFavicon,
           type: 'checkbox',
         },
         isMuted: {

--- a/src/helpers/favicon-helpers.ts
+++ b/src/helpers/favicon-helpers.ts
@@ -1,0 +1,3 @@
+export function getFaviconUrl(url: string, size: number = 128): string {
+  return `https://www.google.com/s2/favicons?sz=${size}&domain_url=${url}`;
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -394,6 +394,7 @@
   "settings.service.form.tabOnPremise": "Self hosted ⭐️",
   "settings.service.form.team": "Team",
   "settings.service.form.trapLinkClicks": "Open URLs within Ferdium",
+  "settings.service.form.useFavicon": "Use service favicon instead of default or custom icon",
   "settings.service.form.useHostedService": "Use the hosted {name} service.",
   "settings.service.form.yourServices": "Your services",
   "settings.service.reloadRequired": "Changes require reload of the service",

--- a/src/internal-server/app/Controllers/Http/ServiceController.js
+++ b/src/internal-server/app/Controllers/Http/ServiceController.js
@@ -53,6 +53,7 @@ class ServiceController {
         isNotificationEnabled: DEFAULT_SERVICE_SETTINGS.isNotificationEnabled,
         isBadgeEnabled: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
         trapLinkClicks: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+        useFavicon: DEFAULT_SERVICE_SETTINGS.useFavicon,
         isMuted: DEFAULT_SERVICE_SETTINGS.isMuted,
         isDarkModeEnabled: '', // TODO: This should ideally be a boolean (false). But, changing it caused the sidebar toggle to not work.
         isProgressbarEnabled: DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
@@ -83,6 +84,7 @@ class ServiceController {
         hasCustomIcon: DEFAULT_SERVICE_SETTINGS.hasCustomIcon,
         isBadgeEnabled: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
         trapLinkClicks: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+        useFavicon: DEFAULT_SERVICE_SETTINGS.useFavicon,
         isDarkModeEnabled: '', // TODO: This should ideally be a boolean (false). But, changing it caused the sidebar toggle to not work.
         isProgressbarEnabled: DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
         isEnabled: DEFAULT_SERVICE_SETTINGS.isEnabled,
@@ -232,6 +234,7 @@ class ServiceController {
         hasCustomIcon: DEFAULT_SERVICE_SETTINGS.customIcon,
         isBadgeEnabled: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
         trapLinkClicks: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+        useFavicon: DEFAULT_SERVICE_SETTINGS.useFavicon,
         isDarkModeEnabled: '', // TODO: This should ideally be a boolean (false). But, changing it caused the sidebar toggle to not work.
         isProgressbarEnabled: DEFAULT_SERVICE_SETTINGS.isProgressbarEnabled,
         isEnabled: DEFAULT_SERVICE_SETTINGS.isEnabled,

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -8,6 +8,7 @@ import { v4 as uuidV4 } from 'uuid';
 import { needsToken } from '../api/apiBase';
 import { DEFAULT_SERVICE_ORDER, DEFAULT_SERVICE_SETTINGS } from '../config';
 import { todosStore } from '../features/todos';
+import { getFaviconUrl } from '../helpers/favicon-helpers';
 import { isValidExternalURL, normalizedUrl } from '../helpers/url-helpers';
 import { ifUndefined } from '../jsUtils';
 import type { IRecipe } from './Recipe';
@@ -134,6 +135,8 @@ export default class Service {
 
   @observable isMediaPlaying: boolean = false;
 
+  @observable useFavicon: boolean = DEFAULT_SERVICE_SETTINGS.useFavicon;
+
   @action _setAutoRun() {
     if (!this.isEnabled) {
       this.webview = null;
@@ -167,6 +170,7 @@ export default class Service {
     this.team = ifUndefined<string>(data.team, this.team);
     this.customUrl = ifUndefined<string>(data.customUrl, this.customUrl);
     this.iconUrl = ifUndefined<string>(data.iconUrl, this.iconUrl);
+    this.useFavicon = ifUndefined<boolean>(data.useFavicon, this.useFavicon);
     this.order = ifUndefined<number>(data.order, this.order);
     this.isEnabled = ifUndefined<boolean>(data.isEnabled, this.isEnabled);
     this.isNotificationEnabled = ifUndefined<boolean>(
@@ -350,6 +354,10 @@ export default class Service {
   }
 
   @computed get icon(): string {
+    if (this.useFavicon) {
+      return getFaviconUrl(this.url);
+    }
+
     if (this.iconUrl) {
       if (needsToken()) {
         let url: URL;

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -472,6 +472,7 @@ export default class ServicesStore extends TypedStore {
       isBadgeEnabled: DEFAULT_SERVICE_SETTINGS.isBadgeEnabled,
       isMediaBadgeEnabled: DEFAULT_SERVICE_SETTINGS.isMediaBadgeEnabled,
       trapLinkClicks: DEFAULT_SERVICE_SETTINGS.trapLinkClicks,
+      useFavicon: DEFAULT_SERVICE_SETTINGS.useFavicon,
       isMuted: DEFAULT_SERVICE_SETTINGS.isMuted,
       customIcon: DEFAULT_SERVICE_SETTINGS.customIcon,
       isDarkModeEnabled: DEFAULT_SERVICE_SETTINGS.isDarkModeEnabled,


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Add ability to use favicons instead of default/custom icons

#### Motivation and Context
This fixes https://github.com/ferdium/ferdium-app/issues/1340 and fixes https://github.com/ferdium/ferdium-app/issues/257.

Issue https://github.com/ferdium/ferdium-app/issues/257 also refers:
> Additionally, will be good to allow paste url of icon, additionally to current ability to upload the icon from local filesystem, because most of favicons are available via url, so we'll can get rid of the "File » Save as + Upload to Ferdium" ritual :)

This is **NOT** included in this PR.

This PR makes use of the Google API for favicons (`https://www.google.com/s2/favicons` as stated in `src/helpers/favicon-helpers.ts`) - let me know if there is any issue on using this.

#### Screenshots
| Without favicon | With favicon |
|-- |-- |
| ![image](https://github.com/ferdium/ferdium-app/assets/37463445/63d53364-662a-414c-9b15-882ad74db380) | ![image](https://github.com/ferdium/ferdium-app/assets/37463445/c6f1995c-b7fa-4067-a452-b6e462d25529) |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Added ability to use favicons instead of default/custom icons (on edit service menu)