### PR TITLE
Fix screenshare on wayland and style

### DIFF
--- a/src/components/MediaSource.tsx
+++ b/src/components/MediaSource.tsx
@@ -1,20 +1,61 @@
 import { ipcRenderer } from 'electron';
-import { useEffect, useState } from 'react';
+import { type MouseEventHandler, useEffect, useState } from 'react';
+import {
+  type WrappedComponentProps,
+  defineMessages,
+  injectIntl,
+} from 'react-intl';
 import { SCREENSHARE_CANCELLED_BY_USER } from '../config';
 import { isWayland } from '../environment';
 import type Service from '../models/Service';
+import FullscreenLoader from './ui/FullscreenLoader';
 
-export interface IProps {
+interface IProps extends WrappedComponentProps {
   service: Service;
 }
 
-export default function MediaSource(props: IProps) {
-  const { service } = props;
+const messages = defineMessages({
+  loading: {
+    id: 'service.screenshare.loading',
+    defaultMessage: 'Loading screens and windows',
+  },
+  cancel: {
+    id: 'service.screenshare.cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+interface ICancelButtonProps extends WrappedComponentProps {
+  handleOnClick: MouseEventHandler<HTMLButtonElement> | undefined;
+}
+
+const CancelButton = injectIntl(
+  ({ handleOnClick, intl }: ICancelButtonProps) => (
+    <li className="desktop-capturer-selection__item">
+      <button
+        type="button" // Add explicit type attribute
+        className="desktop-capturer-selection__btn"
+        data-id={SCREENSHARE_CANCELLED_BY_USER}
+        title="Cancel"
+        onClick={handleOnClick}
+      >
+        <span className="desktop-capturer-selection__name desktop-capturer-selection__name--cancel">
+          {intl.formatMessage(messages.cancel)}
+        </span>
+      </button>
+    </li>
+  ),
+);
+
+function MediaSource(props: IProps) {
+  const { service, intl } = props;
   const [sources, setSources] = useState<any>([]);
   const [show, setShow] = useState<boolean>(false);
   const [trackerId, setTrackerId] = useState<string | null>(null);
+  const [loadingSources, setLoadingSources] = useState<boolean>(false);
 
   ipcRenderer.on(`select-capture-device:${service.id}`, (_event, data) => {
+    if (loadingSources) return;
     setShow(true);
     setTrackerId(data.trackerId);
   });
@@ -30,27 +71,74 @@ export default function MediaSource(props: IProps) {
     });
 
     setShow(false);
+    setSources([]);
     setTrackerId(null);
   };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: This effect should only run when `show` changes
   useEffect(() => {
     if (show) {
-      ipcRenderer.invoke('get-desktop-capturer-sources').then(sources => {
-        if (isWayland) {
-          // On Linux, we do not need to prompt the user again for the source
-          handleOnClick({ currentTarget: { dataset: { id: sources[0].id } } });
-          return;
-        }
-        setSources(sources);
-      });
+      setLoadingSources(true);
+      ipcRenderer
+        .invoke('get-desktop-capturer-sources')
+        .then(sources => {
+          if (isWayland) {
+            // On Linux, we do not need to prompt the user again for the source
+            handleOnClick({
+              currentTarget: { dataset: { id: sources[0].id } },
+            });
+            return;
+          }
+
+          setSources(sources);
+          setLoadingSources(false);
+        })
+        // silence the error
+        .catch(() => {
+          setShow(false);
+          setSources([]);
+          setLoadingSources(false);
+        });
     } else {
       setSources([]);
+      setLoadingSources(false);
     }
   }, [show]);
 
-  if (sources.length === 0 || !show) {
+  if (!show) {
     return null;
+  }
+
+  if (loadingSources) {
+    return (
+      <div className="desktop-capturer-selection">
+        <ul
+          className="desktop-capturer-selection__list"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <FullscreenLoader title={intl.formatMessage(messages.loading)}>
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <CancelButton handleOnClick={handleOnClick} />
+            </div>
+          </FullscreenLoader>
+        </ul>
+      </div>
+    );
+  }
+
+  if (sources.length === 0) {
+    return (
+      <div className="desktop-capturer-selection">
+        <ul className="desktop-capturer-selection__list">
+          <li>No available sources.</li>
+          <CancelButton handleOnClick={handleOnClick} />
+        </ul>
+      </div>
+    );
   }
 
   return (
@@ -74,20 +162,10 @@ export default function MediaSource(props: IProps) {
             </button>
           </li>
         ))}
-        <li className="desktop-capturer-selection__item">
-          <button
-            type="button" // Add explicit type attribute
-            className="desktop-capturer-selection__btn"
-            data-id={SCREENSHARE_CANCELLED_BY_USER}
-            title="Cancel"
-            onClick={handleOnClick}
-          >
-            <span className="desktop-capturer-selection__name desktop-capturer-selection__name--cancel">
-              Cancel
-            </span>
-          </button>
-        </li>
       </ul>
+      <CancelButton handleOnClick={handleOnClick} />
     </div>
   );
 }
+
+export default injectIntl(MediaSource);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -7,6 +7,8 @@ export const isWindows = process.platform === 'win32';
 export const isLinux = process.platform === 'linux';
 export const isWinPortable = process.env.PORTABLE_EXECUTABLE_FILE != null;
 
+export const isWayland = isLinux && process.env.XDG_SESSION_TYPE === 'wayland';
+
 export const electronVersion: string = process.versions.electron ?? '';
 export const chromeVersion: string = process.versions.chrome ?? '';
 export const nodeVersion: string = process.versions.node;

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -164,6 +164,8 @@
   "service.errorHandler.headline": "Oh no!",
   "service.errorHandler.message": "Error",
   "service.errorHandler.text": "{name} has failed to load.",
+  "service.screenshare.cancel": "Cancel",
+  "service.screenshare.loading": "Loading screens and windows",
   "service.webviewLoader.loading": "Loading {service}",
   "services.getStarted": "Get started",
   "services.login": "Please login to use Ferdium.",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Fix screenshare on wayland and style component

#### Motivation and Context
If a user uses wayland it prompts the user twice for selecting a window (one from the native selector from the OS, and another for selecting the single available screen - after the native selection - on Ferdium). This PR removes the second prompt (the only prompt controlled by Ferdium) and instantly retrieves the only available source in the source array.

In this PR I also added some styling and fixes (so that the user sees a loading screen after pressing the screenshare feature - while he waits for the background communication between the main process and render process on getting the available streaming sources.

Tested on:
- [x] MacOS Sonoma
- [x] Windows 11
- [x] Fedora 40 (Wayland)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Fixes the double prompt on screenshare when using Wayland (Linux)