### PR TITLE
fix: macos-notification-state not working well

### DIFF
--- a/build-helpers/entitlements.mas.inherit.plist
+++ b/build-helpers/entitlements.mas.inherit.plist
@@ -18,5 +18,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
   </dict>
 </plist>

--- a/build-helpers/entitlements.mas.plist
+++ b/build-helpers/entitlements.mas.plist
@@ -18,5 +18,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
   </dict>
 </plist>

--- a/src/electron/ipc-api/dnd.ts
+++ b/src/electron/ipc-api/dnd.ts
@@ -8,6 +8,8 @@ export default async () => {
     if (!isMac) {
       return false;
     }
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+    // @ts-ignore
     const { getDoNotDisturb } = await import('macos-notification-state');
 
     if (!getDoNotDisturb) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
- Add the entitlement `com.apple.developer.usernotifications.communication` to allow the app to use the focus state on MacOS properly. 
- Disable the typecheck when importing the `macos-notification-state` module, which prevented building locally on Linux and gave an error on Windows.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
It seems that we have been missing a [key element in the entitlement file](https://github.com/felixrieseberg/macos-notification-state/issues/32#issuecomment-1829263313) in order to allow Focus State to work on MacOS without granting full rights on the disk to Ferdium.
 
Also, when building locally on Linux or Windows, the typecheck happening on the `dnd.ts` file fails since the module is not loaded. Adding these comments to avoid problems in the same vein that we do with `node-mac-permissions` there: 
https://github.com/ferdium/ferdium-app/blob/6f84b89727cb75e3ac4620387964299f551c5ac0/src/electron/macOSPermissions.ts#L5-L7

Important note: I have not tested whether this completely works since my mac does not support Monterrey and above, but currently, it seems to be the last missing piece of the puzzle.

This possibly resolves the following:
Fixes #1047 
Fixes #798 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
