### PR TITLE
Partially revert "fix: macos-notification-state not working well"

### DIFF
--- a/build-helpers/entitlements.mas.inherit.plist
+++ b/build-helpers/entitlements.mas.inherit.plist
@@ -18,7 +18,5 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
-    <key>com.apple.developer.usernotifications.communication</key>
-    <true/>
   </dict>
 </plist>

--- a/build-helpers/entitlements.mas.plist
+++ b/build-helpers/entitlements.mas.plist
@@ -18,7 +18,5 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
-    <key>com.apple.developer.usernotifications.communication</key>
-    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Reverts change of entitlements files from ferdium/ferdium-app#1794
Fixes #1797 

### Description of explaination
It seems that the added entitlement prevents the app from being run after notarization. Even though the app is deemed as correctly signed and notarize, the user will see a prompt saying:
"You do not possess the authorisations needed to open this app. Please contact your administrator to obtain further assistance". 
I do not know at the moment why this is the case, and will investigate this further, but as @vraravam mentioned when running tests, this does not happen on local builds, and may not even be necessary to make the FocusState work as expected.
![Capture d’écran 2024-06-02 à 20 34 47](https://github.com/ferdium/ferdium-app/assets/34252790/8aa39588-b451-4d05-ae4f-6bca6756e08d)
