### PR TITLE
style(tabs): improve visual consistency and label handling for horizontal style

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -248,7 +248,6 @@ const generateServiceRibbonWidthStyle = (
       ${useGrayscaleServices ? graysacleServices : null},
     }
     .tab-item .tab-item__label {
-      margin-left: 4px !important;
       font-size: ${fontSize}px !important;
     }
     .tab-item.is-label-enabled {

--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -147,7 +147,7 @@ const generateServiceRibbonWidthStyle = (
 ) => {
   const width = Number(widthStr);
   const iconSize = Number(iconSizeStr) - iconSizeBias;
-  const tabItemWidthBias = 3;
+  const tabItemWidthBias = 1;
   const verticalStyleOffset = 29;
 
   let fontSize: number;
@@ -252,7 +252,8 @@ const generateServiceRibbonWidthStyle = (
       font-size: ${fontSize}px !important;
     }
     .tab-item.is-label-enabled {
-      padding-bottom: 0px !important;
+      padding-top: 6px !important;
+      padding-bottom: 2px !important;
     }
     .sidebar__button {
       font-size: ${width / 3}px !important;

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -58,8 +58,14 @@
   }
 
   .tab-item__label {
-    display: flex;
     font-size: 11px;
+    width: 100%;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block;
+    text-align: center;
+    padding: 0 8px;
   }
 
   &.is-disabled .tab-item__icon {

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -5,10 +5,6 @@
 
   &.is-active {
     background: $dark-theme-gray;
-
-    .tab-item__icon {
-      margin-left: -4px;
-    }
   }
 
   &.is-disabled .tab-item__icon {
@@ -45,13 +41,12 @@
       $theme-brand-primary,
       $lightness: min(lightness($theme-brand-primary) * 1.35, 100)
     );
-    border-color: $theme-brand-primary;
-    border-left-width: 4px;
-    border-left-style: solid;
+
+    box-shadow: inset 4px 0 0 0 $theme-brand-primary;
 
     .tab-item__icon,
     .tab-item__label {
-      margin-left: -4px;
+      margin-left: 0px;
     }
   }
 

--- a/src/styles/vertical.scss
+++ b/src/styles/vertical.scss
@@ -39,8 +39,8 @@ $tabitem-bias: 30px;
       }
 
       &.is-label-enabled {
-        min-width: 70px;
-        max-width: 140px;
+        min-width: 80px;
+        max-width: 80px;
         height: $sidebar-width + 10;
         width: max-content !important;
         overflow: hidden;
@@ -51,6 +51,10 @@ $tabitem-bias: 30px;
 
       .tab-item__icon {
         margin-left: 0;
+      }
+
+      &__label {
+        padding: 0;
       }
     }
   }

--- a/src/styles/vertical.scss
+++ b/src/styles/vertical.scss
@@ -33,15 +33,9 @@ $tabitem-bias: 30px;
 
     .tab-item {
       &.is-active {
-        border-left-width: 0px !important;
-        border-top-width: 4px;
-        border-top-style: solid;
+        box-shadow: inset 0 4px 0 0 $theme-brand-primary;
         overflow: hidden;
         height: $sidebar-width + 4;
-      }
-
-      &:not(.is-active) {
-        padding-top: 4px;
       }
 
       &.is-label-enabled {

--- a/src/styles/vertical.scss
+++ b/src/styles/vertical.scss
@@ -39,8 +39,8 @@ $tabitem-bias: 30px;
       }
 
       &.is-label-enabled {
-        min-width: 80px;
-        max-width: 80px;
+        min-width: 100px;
+        max-width: 100px;
         height: $sidebar-width + 10;
         width: max-content !important;
         overflow: hidden;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
When we move the sidebar to the top and show the services label, we get a very inconsistent visual.
The service tab width is different according to the size of the service label and the active indicator pushes everything down, so the active service tab keeps unaligned with all the others.

In this PR I fixed both issues by using a fixed width for all the tabs when labels are displayed and using box-shadow instead of a border for the active tab indicator so things are not pushed down, This way we have a more consistent look for all the tabs and the whole application in general.

Another problem is that the long labels were not "ellipsed, I fixed this too.

#### Motivation and Context
I prefer to use the tabs at the top of the application, but all these little issues prevented me from doing so because they bothered me a lot.

#### Screenshots
Before:
![Screenshot_20241024_181046](https://github.com/user-attachments/assets/debcca23-bc41-4aed-9951-6cd6fd5b7d6b)
![Screenshot_20241024_181052](https://github.com/user-attachments/assets/d61a3f05-04f0-4983-9b53-5fd65825131a)

After:
![Screenshot_20241024_181224](https://github.com/user-attachments/assets/cd414fd2-79bb-4db6-850d-8ea48ef9a926)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`pnpm prepare-code`)
- [X] `pnpm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes
- All tabs, when the service label is enabled and the sidebar is on the top, now have the same width, labels get ellipsed and the activated tab is no longer un-aligned with others.
