### PR TITLE
fix: update appearance/index.ts to apply the accent color on tabs

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -41,7 +41,7 @@ const generateUserCustomCSS = () => {
   return pathExistsSync(path) ? readFileSync(path).toString() : '';
 };
 
-const generateAccentStyle = accentColorStr => {
+const generateAccentStyle = (accentColorStr, useHorizontalStyle) => {
   let accentColor;
   try {
     accentColor = color(accentColorStr);
@@ -97,7 +97,7 @@ const generateAccentStyle = accentColorStr => {
     }
 
     .franz-form .franz-form__radio.is-selected, .tab-item.is-active {
-      box-shadow: inset 4px 0 0 0 ${accentColorStr};
+      box-shadow: inset ${useHorizontalStyle ? '0 4px' : '4px 0'} 0 0 ${accentColorStr};
     }
 
     a.button:hover, button.button:hover {
@@ -405,7 +405,7 @@ const generateStyle = (settings, app) => {
   if (
     accentColor.toLowerCase() !== DEFAULT_APP_SETTINGS.accentColor.toLowerCase()
   ) {
-    style += generateAccentStyle(accentColor);
+    style += generateAccentStyle(accentColor, useHorizontalStyle);
   }
 
   style += generateServiceRibbonWidthStyle(

--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -97,7 +97,7 @@ const generateAccentStyle = accentColorStr => {
     }
 
     .franz-form .franz-form__radio.is-selected, .tab-item.is-active {
-      border-color: ${accentColorStr};
+      box-shadow: inset 4px 0 0 0 ${accentColorStr};
     }
 
     a.button:hover, button.button:hover {

--- a/src/styles/vertical.scss
+++ b/src/styles/vertical.scss
@@ -33,7 +33,6 @@ $tabitem-bias: 30px;
 
     .tab-item {
       &.is-active {
-        box-shadow: inset 0 4px 0 0 $theme-brand-primary;
         overflow: hidden;
         height: $sidebar-width + 4;
       }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
After this previous PR https://github.com/ferdium/ferdium-app/pull/1944, as stated by @wvds here https://github.com/ferdium/ferdium-app/pull/1944#issuecomment-2470225090, the accent color was not being updated in tabs. This happened because, with the change from `border` to `box-shadow`, I forgot to update the `appearance/index.ts`, where we do this change. It was still changing the `border-color`, but since there is no more `border`, it was doing nothing. I just needed to update the code there to use the `box-shadow`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
This is a bug.

#### Screenshots
<!-- Remove the section if this does not apply. -->
![image](https://github.com/user-attachments/assets/d29a3ac0-e940-4455-96e0-078171c5948a)
![image](https://github.com/user-attachments/assets/f43ff934-fa32-4675-ae04-5bdbf2f314a1)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`pnpm prepare-code`)
- [X] `pnpm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes
Fix the problem that was causing the accent colors to not be applied to tabs indicator

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
