### PR TITLE
feat: option to use `Alt+[0-9]` to select service

### DIFF
--- a/src/components/services/tabs/TabItem.tsx
+++ b/src/components/services/tabs/TabItem.tsx
@@ -366,7 +366,10 @@ class TabItem extends Component<IProps, IState> {
         data-tooltip-id="tooltip-sidebar-button"
         data-tooltip-content={`${service.name} ${acceleratorString({
           index: shortcutIndex,
-          keyCombo: cmdOrCtrlShortcutKey(false),
+          keyCombo: this.props.stores!.settings.all.shortcuts
+            .activateServiceUsesAlt
+            ? altKey()
+            : cmdOrCtrlShortcutKey(false),
         })}`}
       >
         <img src={service.icon} className="tab-item__icon" alt="" />

--- a/src/components/settings/settings/EditSettingsForm.tsx
+++ b/src/components/settings/settings/EditSettingsForm.tsx
@@ -1235,6 +1235,8 @@ class EditSettingsForm extends Component<IProps, IState> {
                     onChange={e => this.submit(e)}
                     {...form.$('shortcutActivatePreviousService').bind()}
                   />
+
+                  <Toggle {...form.$('activateServiceUsesAlt').bind()} />
                 </div>
               </div>
             )}

--- a/src/config.ts
+++ b/src/config.ts
@@ -476,4 +476,5 @@ export const DEFAULT_SERVICE_SETTINGS = {
 export const DEFAULT_SHORTCUTS = {
   activateNextService: 'Ctrl+tab',
   activatePreviousService: `Ctrl+${shiftKey()}+tab`,
+  activateServiceUsesAlt: false,
 };

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -509,6 +509,7 @@ class EditSettingsScreen extends Component<
     const newShortcuts = {
       activateNextService: settingsData.shortcutActivateNextService,
       activatePreviousService: settingsData.shortcutActivatePreviousService,
+      activateServiceUsesAlt: Boolean(settingsData.activateServiceUsesAlt),
     };
 
     const requiredRestartKeys = [
@@ -1341,6 +1342,15 @@ class EditSettingsScreen extends Component<
           ),
           default: DEFAULT_SHORTCUTS.activatePreviousService,
           placeholder: DEFAULT_SHORTCUTS.activatePreviousService,
+        },
+        activateServiceUsesAlt: {
+          label: intl.formatMessage(menuItems.activateServiceUsesAlt),
+          value: ifUndefined<boolean>(
+            settings.all.shortcuts.activateServiceUsesAlt,
+            DEFAULT_SHORTCUTS.activateServiceUsesAlt,
+          ),
+          default: DEFAULT_SHORTCUTS.activateServiceUsesAlt,
+          type: 'checkbox',
         },
       },
     };

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -113,6 +113,7 @@
   "menu.help.tos": "Terms of Service",
   "menu.services": "Services",
   "menu.services.activatePreviousService": "Activate previous service",
+  "menu.services.activateServiceUsesAlt": "Use Alt key to activate service",
   "menu.services.addNewService": "Add New Service...",
   "menu.services.copyToClipboard": "Copy to clipboard",
   "menu.services.goHome": "Home",

--- a/src/lib/Menu.ts
+++ b/src/lib/Menu.ts
@@ -304,6 +304,10 @@ export const menuItems = defineMessages({
     id: 'menu.services.activatePreviousService',
     defaultMessage: 'Activate previous service',
   },
+  activateServiceUsesAlt: {
+    id: 'menu.services.activateServiceUsesAlt',
+    defaultMessage: 'Use Alt key to activate service',
+  },
   muteApp: {
     id: 'sidebar.muteApp',
     defaultMessage: 'Disable notifications & audio',
@@ -1145,7 +1149,9 @@ class FranzMenu implements StoresProps {
         label: this._getServiceName(service),
         accelerator: acceleratorString({
           index: i + 1,
-          keyCombo: cmdOrCtrlShortcutKey(),
+          keyCombo: this.stores.settings.shortcuts.activateServiceUsesAlt
+            ? altKey()
+            : cmdOrCtrlShortcutKey(),
           prefix: '',
           suffix: '',
         }),


### PR DESCRIPTION
Closes #1971, and shares similarity with #1920

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Add an option to `Settings > Advances > Shortcuts` to use `Alt` modifier (instead of `Ctrl`) to select current service with number keys.
The input is unchecked by default. If the input is checked, the user cannot use `Ctrl+[0-9]` to activate a service, but instead must use `Alt+[0-9]` (similar to Firefox). This does not impact users who do not manually enable the feature.

I have placed the toggle option below the shortcut inputs implemented by #1920 because it seems the most appropriate location. Likewise the state is stored in `stores.shortcuts`. This can of course be changed if deemed necessary.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
I use Firefox, so I am accustomed to using `Alt+[0-9]` to switch tabs (rather than `Ctrl+[0-9]`).
Closes #1971 by implementing the second proposed solution (issue provides 3 possible solutions).

#### Screenshots
<!-- Remove the section if this does not apply. -->
![image](https://github.com/user-attachments/assets/f0723a8a-3a3a-4ad0-9ac4-83ef5b092f5f)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Add option to use `Alt+[0-9]` to select service.
