### PR TITLE
upgrade docker image, fix readme, remove deprecated gem-install flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Ferdium 6
+# Contributing to Ferdium 7
 
 :tada: First off, thanks for taking the time and your effort to make Ferdium better! :tada:
 
@@ -6,7 +6,7 @@
 
 <!-- TOC depthFrom:2 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-- [Contributing to Ferdium 6](#contributing-to-ferdium-6)
+- [Contributing to Ferdium 7](#contributing-to-ferdium-7)
   - [Table of contents](#table-of-contents)
   - [Code of Conduct](#code-of-conduct)
   - [What should I know before I get started?](#what-should-i-know-before-i-get-started)
@@ -39,7 +39,7 @@ Please report unacceptable behavior to [hello@ferdium.org](mailto:hello@ferdium.
 
 ## What should I know before I get started?
 
-For the moment, Ferdium's development is only starting, aiming at releasing a 6.0.0 version with the rebranded assets and tooling upgrade completed. You can join our official [Discord chat](https://discord.com/invite/xpNTzgKmHM) to get more updates and discuss issues with the other contributors.
+You can join our official [Discord chat](https://discord.com/invite/xpNTzgKmHM) to get more updates and discuss issues with the other contributors.
 
 ## How can I contribute?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The version [2.23.0](https://git-scm.com/download) for Git is working fine for d
 #### On Debian/Ubuntu
 
 ```bash
-apt-get update -y && apt-get install --no-install-recommends -y rpm ruby gem && gem install fpm --no-ri --no-rdoc --no-document
+apt-get update -y && apt-get install --no-install-recommends -y rpm ruby gem && gem install fpm --no-document
 ```
 
 #### On Fedora

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG PREVAL_BUILD_INFO_PLACEHOLDERS=true
 # Note: 'fpm' is needed for building on ARM machines
 RUN apt-get update -y \
   && apt-get install --no-install-recommends -y rpm ruby gem \
-  && gem install dotenv -v 2.8.1 --no-ri --no-rdoc --no-document \
-  && gem install fpm --no-ri --no-rdoc --no-document
+  && gem install dotenv -v 2.8.1 --no-document \
+  && gem install fpm --no-document
 
 WORKDIR /usr/src/ferdium
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,12 @@ RUN pnpm i && pnpm lint && pnpm reformat-files && pnpm package
 
 WORKDIR /usr/src/ferdium
 
-RUN pnpm build --dir
+RUN arch="$(dpkg --print-architecture)"; \
+        case "$arch" in \
+            *arm*) TARGET_ARCH=arm64 ;; \
+            *)     TARGET_ARCH=x64 ;; \
+        esac; \
+        pnpm build --$TARGET_ARCH --dir
 
 # --------------------------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Note: Before running this file, you should have already cloned the git repo + submodules on the host machine. This is used when actively developing on your local machine, but you want to build for a different architecture
 
-FROM docker.io/library/node:20.18.0-buster AS builder
+FROM docker.io/library/node:20.18.0-bookworm AS builder
 
 ENV PATH="/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/lib:/usr/include:/usr/share"
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -346,7 +346,7 @@ export default class AppStore extends TypedStore {
     if (isMac && !localStorage.getItem(CATALINA_NOTIFICATION_HACK_KEY)) {
       debug('Triggering macOS Catalina notification permission trigger');
       // eslint-disable-next-line no-new
-      new window.Notification('Welcome to Ferdium 6', {
+      new window.Notification('Welcome to Ferdium 7', {
         body: 'Have a wonderful day & happy messaging.',
       });
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
- update references to Ferdium 6 -> 7 throughout the documentation/code
- upgrade Dockerfile baseimage to Bookworm (current Debian stable)
- remove deprecated `gem install` options `--no-ri` & `--no-rdoc` that cause installation to fail
- add architecture detection to `pnpm build` in Dockerfile

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
Main importance are the Dockerfile baseimage upgrade as currently used image is no longer available. This in turn pulls in newer ruby/gem which causes `gem install` statements to fail due to abovementioned deprecated options.

Basically this change re-enables the ability to build ferdium via provided Dockerfile.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [ ] The changes respect the code style of the project (`pnpm prepare-code`)
- [ ] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

none