### PR TITLE
fix: dnd not working on devmode on macos

### DIFF
--- a/src/electron/ipc-api/dnd.ts
+++ b/src/electron/ipc-api/dnd.ts
@@ -1,10 +1,16 @@
 import { ipcMain } from 'electron';
+import { isDevMode } from '../../environment-remote';
 import { isMac } from '../../environment';
 
 const debug = require('../../preload-safe-debug')('Ferdium:ipcApi:dnd');
 
 export default async () => {
   ipcMain.handle('get-dnd', async () => {
+    // In dev mode, we don't want to check DND status because it's not available
+    // TODO: This should be removed when we have a better way to handle this
+    if (isDevMode) {
+      return false;
+    }
     if (!isMac) {
       return false;
     }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
fix: dnd not working on devmode on macos

#### Motivation and Context
On macOS whenever you try to use `pnpm debug` the software crashes because of permissions that are only bundled with electron-builder (`Info.plist` file)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally
