### PR TITLE
fix: give default value to shortcuts accelerators in menu

### DIFF
--- a/src/lib/Menu.ts
+++ b/src/lib/Menu.ts
@@ -18,7 +18,11 @@ import type { StoresProps } from '../@types/ferdium-components.types';
 import { importExportURL, serverBase, serverName } from '../api/apiBase';
 // @ts-expect-error Cannot find module '../buildInfo.json' or its corresponding type declarations.
 import { gitBranch, gitHashShort, timestamp } from '../buildInfo.json';
-import { CUSTOM_WEBSITE_RECIPE_ID, LIVE_API_FERDIUM_WEBSITE } from '../config';
+import {
+  CUSTOM_WEBSITE_RECIPE_ID,
+  DEFAULT_SHORTCUTS,
+  LIVE_API_FERDIUM_WEBSITE,
+} from '../config';
 import {
   addNewServiceShortcutKey,
   altKey,
@@ -1106,7 +1110,9 @@ class FranzMenu implements StoresProps {
       },
       {
         label: intl.formatMessage(menuItems.activateNextService),
-        accelerator: this.stores.settings.shortcuts.activateNextService,
+        accelerator:
+          this.stores.settings?.shortcuts?.activateNextService ??
+          DEFAULT_SHORTCUTS.activateNextService,
         click: () => this.actions.service.setActiveNext(),
         visible: !cmdAltShortcutsVisibile,
       },
@@ -1118,7 +1124,9 @@ class FranzMenu implements StoresProps {
       },
       {
         label: intl.formatMessage(menuItems.activatePreviousService),
-        accelerator: this.stores.settings.shortcuts.activatePreviousService,
+        accelerator:
+          this.stores.settings?.shortcuts?.activatePreviousService ??
+          DEFAULT_SHORTCUTS.activatePreviousService,
         click: () => this.actions.service.setActivePrev(),
         visible: !cmdAltShortcutsVisibile,
       },

--- a/src/lib/Menu.ts
+++ b/src/lib/Menu.ts
@@ -51,7 +51,7 @@ import { workspaceStore } from '../features/workspaces/index';
 import { onAuthGoToReleaseNotes } from '../helpers/update-helpers';
 import { openExternalUrl } from '../helpers/url-helpers';
 import globalMessages from '../i18n/globalMessages';
-import { acceleratorString } from '../jsUtils';
+import { acceleratorString, ifUndefined } from '../jsUtils';
 import type Service from '../models/Service';
 import type { RealStores } from '../stores';
 
@@ -1110,9 +1110,10 @@ class FranzMenu implements StoresProps {
       },
       {
         label: intl.formatMessage(menuItems.activateNextService),
-        accelerator:
-          this.stores.settings?.shortcuts?.activateNextService ??
+        accelerator: ifUndefined<string>(
+          this.stores.settings.shortcuts.activateNextService,
           DEFAULT_SHORTCUTS.activateNextService,
+        ),
         click: () => this.actions.service.setActiveNext(),
         visible: !cmdAltShortcutsVisibile,
       },
@@ -1124,9 +1125,10 @@ class FranzMenu implements StoresProps {
       },
       {
         label: intl.formatMessage(menuItems.activatePreviousService),
-        accelerator:
-          this.stores.settings?.shortcuts?.activatePreviousService ??
+        accelerator: ifUndefined<string>(
+          this.stores.settings.shortcuts.activatePreviousService,
           DEFAULT_SHORTCUTS.activatePreviousService,
+        ),
         click: () => this.actions.service.setActivePrev(),
         visible: !cmdAltShortcutsVisibile,
       },


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Give a default value to the shortcuts accelerators in the menu so that it does not crash if the store has not yet updated with the new settings. This comes from the possibility to have custom shortcuts as implemented in #1920.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
As reported by some user in the Discord, it seems that for some people on Windows 10, the update that allowed custom shortcuts cause a complete unusable app. This potentially relates to a startup race condition occurring when the store is not updated with the correct settings of the shortcuts when the application starts, thus causing an issue when trying to create the menu if it is undefined.

Note: I was not able to reproduce the initial error, so even though this seems to work fine on my computers, I cannot make sure that it fully fixes the problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
