### PR TITLE
feat: toggle global DND when receiving a notification during scheduled DND

### DIFF
--- a/src/electron/ipc-api/dnd.ts
+++ b/src/electron/ipc-api/dnd.ts
@@ -5,15 +5,18 @@ import { isDevMode } from '../../environment-remote';
 const debug = require('../../preload-safe-debug')('Ferdium:ipcApi:dnd');
 
 export default async () => {
-  ipcMain.handle('get-dnd', async () => {
+  ipcMain.handle('get-dnd-macos', async () => {
     // In dev mode, we don't want to check DND status because it's not available
     // TODO: This should be removed when we have a better way to handle this
     if (isDevMode) {
       return false;
     }
+
     if (!isMac) {
+      console.error("get-dnd-macos shouldn't be called when not on a Mac");
       return false;
     }
+
     // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
     // @ts-ignore
     const { getDoNotDisturb } = await import('macos-notification-state');

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -218,8 +218,10 @@ export default class AppStore extends TypedStore {
 
     // Check if system is muted
     // There are no events to subscribe so we need to poll every 5s
-    this._systemDND();
-    setInterval(() => this._systemDND(), ms('5s'));
+    if (isMac) {
+      this._systemDNDMac();
+      setInterval(() => this._systemDNDMac(), ms('5s'));
+    }
 
     this.fetchDataInterval = setInterval(() => {
       this.stores.user.getUserInfoRequest.invalidate({
@@ -830,10 +832,13 @@ export default class AppStore extends TypedStore {
     return autoLauncher.isEnabled() || false;
   }
 
-  async _systemDND() {
-    debug('Checking if Do Not Disturb Mode is on');
-    const dnd = await ipcRenderer.invoke('get-dnd');
-    debug('Do not disturb mode is', dnd);
+  /**
+   * This method could be refactored to be used on all desktop environments,
+   * but at the moment it only supports MacOS
+   */
+  async _systemDNDMac() {
+    const dnd = await ipcRenderer.invoke('get-dnd-macos');
+    debug('Checking if Do Not Disturb Mode is on :', dnd);
     if (
       dnd !== this.stores.settings.all.app.isAppMuted &&
       !this.isSystemMuteOverridden

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -863,18 +863,18 @@ export default class ServicesStore extends TypedStore {
 
         if (isTwoFactorAutoCatcherEnabled) {
           /*
-        parse the token digits from sms body, find "token" or "code" in options.body which reflect the sms content
-        ---
-        Token: 03624 / SMS-Code = PIN Token
-        ---
-        Prüfcode 010313 für Microsoft-Authentifizierung verwenden.
-        ---
-        483133 is your GitHub authentication code. @github.com #483133
-        ---
-        eBay: Ihr Sicherheitscode lautet 080090. \nEr läuft in 15 Minuten ab. Geben Sie den Code nicht an andere weiter.
-        ---
-        PayPal: Ihr Sicherheitscode lautet: 989605. Geben Sie diesen Code nicht weiter.
-      */
+            parse the token digits from sms body, find "token" or "code" in options.body which reflect the sms content
+            ---
+            Token: 03624 / SMS-Code = PIN Token
+            ---
+            Prüfcode 010313 für Microsoft-Authentifizierung verwenden.
+            ---
+            483133 is your GitHub authentication code. @github.com #483133
+            ---
+            eBay: Ihr Sicherheitscode lautet 080090. \nEr läuft in 15 Minuten ab. Geben Sie den Code nicht an andere weiter.
+            ---
+            PayPal: Ihr Sicherheitscode lautet: 989605. Geben Sie diesen Code nicht weiter.
+          */
 
           const rawBody = options.body;
           const { 0: token } = /\d{5,6}/.exec(options.body) || [];
@@ -899,14 +899,24 @@ export default class ServicesStore extends TypedStore {
         }
 
         // Check if we are in scheduled Do-not-Disturb time
-        const { scheduledDNDEnabled, scheduledDNDStart, scheduledDNDEnd } =
-          this.stores.settings.all.app;
+        if (this.stores.settings.all.app.scheduledDNDEnabled) {
+          const { scheduledDNDStart, scheduledDNDEnd } =
+            this.stores.settings.all.app;
 
-        if (
-          scheduledDNDEnabled &&
-          isInTimeframe(scheduledDNDStart, scheduledDNDEnd)
-        ) {
-          return;
+          const shouldBeDnd = isInTimeframe(scheduledDNDStart, scheduledDNDEnd);
+          debug(
+            'Check if we are in a schedule Do not disturb window :',
+            shouldBeDnd,
+            scheduledDNDStart,
+            scheduledDNDEnd,
+          );
+
+          if (shouldBeDnd !== this.stores.settings.all.app.isAppMuted) {
+            debug('Toggle scheduled Do not disturb');
+            this.actions.app.muteApp({
+              isMuted: shouldBeDnd,
+            });
+          }
         }
 
         if (service.isMuted || this.stores.settings.all.app.isAppMuted) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

Scheduled DND now mute all notifications and sounds from all services, instead of "just" disabling the notification sent to the OS.

I also removed the periodic check of _systemDND on OSes where it's doesn't work ; it is only implemented on Mac at the moment.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->

I really like the Schedule DND feature, but as currently, it doesn't remove the sound of notifications of services like Mattermost or WhatsApp.
With this change, schedule DND works as I expected : it toggles the global switch during the scheduled times, instead of _silently_ (because it's not shown in the UI) hiding the OS notification.

#### Other implementation

I would have preferred to activate and deactivate the global switch at the scheduled times, instead of checking it for each notification, but I didn't have the time to figure out how to schedule code in Electron.
This other implementation would allow users to manually deactivate DND in a scheduled period, or manually activate it while not in a scheduled period.

As this is a real problem, I will let this PR as draft until I figure out how to implement this correctly.

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Scheduled DND now toggles the global "Disable notifications & audio" switch, which allows to mute all notifications sounds