### PR TITLE
fix: add monkey patch for service worker notifications

### DIFF
--- a/src/webview/notifications.ts
+++ b/src/webview/notifications.ts
@@ -78,4 +78,15 @@ class Notification {
 }
 
   window.Notification = Notification;
+
+  // some sites use service workers for notifications, but electron doesn't support this
+  // this is a monkey patch to redirect them to window.Notification instead
+  window.ServiceWorkerRegistration.prototype.showNotification = function (
+    title = '',
+    options = {},
+  ) {
+    // passing all of options causes notifications to only appear sometimes
+    // but the only option that actually matters is body
+    new Notification(title, { body: options.body });
+  };
 })();`;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Some apps use service workers to deliver notifications, however this feature is not supported by Electron. A small monkey patch can be used to redirect all calls to `new Notification()` instead.

#### Motivation and Context
Fixes #1538
I originally submitted this in https://github.com/ferdium/ferdium-recipes/pull/629/, but it was suggested to put it in the main program so all apps can benefit

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
notes: Fixed notification delivery in apps that used service workers.
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->