### PR TITLE
fix: update banner on snap appearing all the time

### DIFF
--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -31,6 +31,7 @@ export interface IProps extends WrappedComponentProps {
   installAppUpdate: MouseEventHandler<HTMLButtonElement>;
   appUpdateIsDownloaded: boolean;
   updateVersion: string;
+  isUpdateAvailable: boolean;
 }
 
 interface IState {
@@ -60,6 +61,7 @@ class AuthLayout extends Component<IProps, IState> {
       appUpdateIsDownloaded,
       updateVersion,
       intl,
+      isUpdateAvailable,
     } = this.props;
 
     let serverNameParse = serverName();
@@ -81,7 +83,7 @@ class AuthLayout extends Component<IProps, IState> {
               {intl.formatMessage(globalMessages.notConnectedToTheInternet)}
             </InfoBar>
           )}
-          {(appUpdateIsDownloaded || isSnap) &&
+          {(appUpdateIsDownloaded || (isSnap && isUpdateAvailable)) &&
             this.state.shouldShowAppUpdateInfoBar && (
               <AppUpdateInfoBar
                 onInstallUpdate={installAppUpdate}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -80,6 +80,7 @@ const toggleFullScreen = () => {
 
 interface IProps extends WrappedComponentProps, WithStylesProps<typeof styles> {
   settings: SettingsStore;
+  isUpdateAvailable: boolean;
   updateVersion: string;
   isFullScreen: boolean;
   sidebar: React.ReactElement;
@@ -128,6 +129,7 @@ class AppLayout extends Component<PropsWithChildren<IProps>, IState> {
       retryRequiredRequests,
       areRequiredRequestsLoading,
       updateVersion,
+      isUpdateAvailable,
     } = this.props;
 
     const { intl } = this.props;
@@ -204,7 +206,7 @@ class AppLayout extends Component<PropsWithChildren<IProps>, IState> {
                     </InfoBar>
                   )}
                 {automaticUpdates &&
-                  (appUpdateIsDownloaded || isSnap) &&
+                  (appUpdateIsDownloaded || (isSnap && isUpdateAvailable)) &&
                   this.state.shouldShowAppUpdateInfoBar && (
                     <AppUpdateInfoBar
                       onInstallUpdate={installAppUpdate}

--- a/src/containers/auth/AuthLayoutContainer.tsx
+++ b/src/containers/auth/AuthLayoutContainer.tsx
@@ -50,6 +50,9 @@ class AuthLayoutContainer extends Component<IProps> {
             app.updateStatus === app.updateStatusTypes.DOWNLOADED
           }
           updateVersion={app.updateVersion}
+          isUpdateAvailable={
+            app.updateStatus === app.updateStatusTypes.AVAILABLE
+          }
         >
           <Outlet />
         </AuthLayout>

--- a/src/containers/layout/AppLayoutContainer.tsx
+++ b/src/containers/layout/AppLayoutContainer.tsx
@@ -193,6 +193,9 @@ class AppLayoutContainer extends Component<IProps> {
             retryRequiredRequests={retryRequiredRequests}
             areRequiredRequestsLoading={requests.areRequiredRequestsLoading}
             updateVersion={app.updateVersion}
+            isUpdateAvailable={
+              app.updateStatus === app.updateStatusTypes.AVAILABLE
+            }
           >
             <Outlet />
           </AppLayout>

--- a/src/electron/ipc-api/autoUpdate.ts
+++ b/src/electron/ipc-api/autoUpdate.ts
@@ -13,6 +13,12 @@ export default (params: { mainWindow: BrowserWindow; settings: any }) => {
   // autoUpdater.forceDevUpdateConfig = true;
 
   if (enableUpdate) {
+    // Disable auto download for snap packages
+    // since the snap store will handle the update.
+    if (isSnap) {
+      autoUpdater.autoDownload = false;
+    }
+
     ipcMain.on('autoUpdate', (event, args) => {
       if (enableUpdate) {
         try {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Fix the update banner always showing up on the snap version, regardless of wether there was actually a new version.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
In #2079 some changes were introduced to prevent snap users from trying to update the app by downloading the `.deb` file. However, a test was added to show the update banner when the user has a snap version, but was missing to check whether the app actually has an update available, which meant this banner was always showing. This PR makes sure this only happen when it should.

Fix #2112. 

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
