### PR TITLE
fix: services with self-signed certificates should load

### DIFF
--- a/src/helpers/certs-helpers.ts
+++ b/src/helpers/certs-helpers.ts
@@ -5,29 +5,38 @@ import { ensureDirSync, readFileSync, readdirSync } from 'fs-extra';
 import { userDataCertsPath } from '../environment-remote';
 import { removeNewLines } from '../jsUtils';
 
+const debug = require('../preload-safe-debug')('Ferdium:App');
+
 export const checkIfCertIsPresent = (clientCert: Certificate): boolean => {
   const certsFolder = userDataCertsPath();
 
   ensureDirSync(certsFolder);
 
   const certs: string[] = [];
+  const clientCertHasCA: boolean = clientCert.issuerCert !== undefined;
+  let certToVerify: X509Certificate | undefined;
 
   try {
-    const certToVerify = new X509Certificate(clientCert.issuerCert.data);
+    if (clientCertHasCA) {
+      certToVerify = new X509Certificate(clientCert.issuerCert.data);
+    }
 
     for (const file of readdirSync(certsFolder)) {
       const cert = readFileSync(join(certsFolder, file), {
         encoding: 'utf8',
         flag: 'r',
       });
-      const caCert = new X509Certificate(cert);
-      if (caCert.ca && certToVerify.verify(caCert.publicKey)) {
-        return true;
+      if (clientCertHasCA) {
+        const caCert = new X509Certificate(cert);
+        if (caCert.ca && certToVerify?.verify(caCert.publicKey)) {
+          return true;
+        }
       }
+
       certs.push(removeNewLines(cert));
     }
   } catch (error) {
-    console.error(error);
+    debug('Error when parsing the certificates:', error);
   }
 
   return certs.length > 0 && certs.includes(removeNewLines(clientCert.data));


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Update the handle of certificates to fix a problem with self-signed certificates.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve?  If it fixes an open issue, please link to the issue here. -->
In #2054, the verification for custom root CA was enabled but it created a problem when the browser received a self-signed certificate since it would then have an empty `issuerCert` field. This meant that the certificates from the local folder were never added to the list of read certificate and the basic verification of direct comparison between the certificate received and those allowed would fail, independent of the presence of said self-certificate in the appropriate folder. This PR resolves the problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] _Someone_ tested/previewed my changes locally (the user who mentioned the problem tried a build I gave them with this fix)

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
