### PR TITLE
feat: Add Recipe poll interval configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -656,6 +656,7 @@ export const DEFAULT_SERVICE_SETTINGS = {
   darkReaderBrightness: 100,
   darkReaderContrast: 90,
   darkReaderSepia: 10,
+  pollDelay: 2000 /* 2000ms */,
 };
 
 export const DEFAULT_SHORTCUTS = {

--- a/src/models/Recipe.ts
+++ b/src/models/Recipe.ts
@@ -25,6 +25,7 @@ interface RecipeData {
     local?: boolean;
     message?: string;
     allowFavoritesDelineationInUnreadCount?: boolean;
+    pollDelay?: number;
   };
   defaultIcon: string;
 }
@@ -51,6 +52,7 @@ export interface IRecipe {
   partition: string;
   local: boolean;
   defaultIcon: string;
+  pollDelay: number;
 
   readonly overrideUserAgent?: () => string;
 
@@ -112,6 +114,8 @@ export default class Recipe implements IRecipe {
   path = '';
 
   partition = '';
+
+  pollDelay = DEFAULT_SERVICE_SETTINGS.pollDelay;
 
   // TODO: Is this being used?
   local = false;
@@ -188,6 +192,7 @@ export default class Recipe implements IRecipe {
       data.config.allowFavoritesDelineationInUnreadCount,
       this.allowFavoritesDelineationInUnreadCount,
     );
+    this.pollDelay = ifUndefined<number>(data.config.pollDelay, this.pollDelay);
 
     // computed
     this.path = data.path;

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -126,6 +126,8 @@ export default class Service {
 
   @observable lastHibernated: number | null = null; // timestamp
 
+  @observable pollDelay: number = 2000; // interval for Recipe Polling
+
   @observable lastPoll: number = Date.now();
 
   @observable lastPollAnswer: number = Date.now();

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -126,7 +126,7 @@ export default class Service {
 
   @observable lastHibernated: number | null = null; // timestamp
 
-  @observable pollDelay: number = 2000; // interval for Recipe Polling
+  @observable pollDelay: number = DEFAULT_SERVICE_SETTINGS.pollDelay; // interval for Recipe Polling
 
   @observable lastPoll: number = Date.now();
 
@@ -239,7 +239,11 @@ export default class Service {
       data.isWakeUpEnabled,
       this.isWakeUpEnabled,
     );
-
+    this.pollDelay = ifUndefined<number>(
+      recipe.pollDelay <= data.pollDelay ? data.pollDelay : recipe.pollDelay,
+      this.pollDelay,
+    );
+    // console.log('ctor-recipe', recipe);
     // Check if "Hibernate on Startup" is enabled and hibernate all services except active one
     const { hibernateOnStartup } = window['ferdium'].stores.settings.app;
     // The service store is probably not loaded yet so we need to use localStorage data to get active service

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -481,6 +481,7 @@ export default class ServicesStore extends TypedStore {
       spellcheckerLanguage:
         SPELLCHECKER_LOCALES[this.stores.settings.app.spellcheckerLanguage],
       userAgentPref: '',
+      pollDelay: DEFAULT_SERVICE_SETTINGS.pollDelay,
       ...serviceData,
     };
 
@@ -983,15 +984,6 @@ export default class ServicesStore extends TypedStore {
         Object.assign(args[0].data, { serviceId });
         this.actions.todos.handleHostMessage(args[0]);
 
-        break;
-      }
-      case 'set-loop-delay': {
-        debug('Received set-loop-delay request from', serviceId);
-        const defaultDelay = ms('2s');
-        let parsedData = ms(`${args[0]}`);
-        if (parsedData < defaultDelay) parsedData = defaultDelay;
-
-        service.pollDelay = parsedData;
         break;
       }
       // No default

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -985,6 +985,15 @@ export default class ServicesStore extends TypedStore {
 
         break;
       }
+      case 'set-loop-delay': {
+        debug('Received set-loop-delay request from', serviceId);
+        const defaultDelay = ms('2s');
+        let parsedData = ms(`${args[0]}`);
+        if (parsedData < defaultDelay) parsedData = defaultDelay;
+
+        service.pollDelay = parsedData;
+        break;
+      }
       // No default
     }
   }
@@ -1442,8 +1451,6 @@ export default class ServicesStore extends TypedStore {
   _initRecipePolling(serviceId: string) {
     const service = this.one(serviceId);
 
-    const delay = ms('2s');
-
     if (service) {
       if (service.timer !== null) {
         clearTimeout(service.timer);
@@ -1454,7 +1461,7 @@ export default class ServicesStore extends TypedStore {
 
         service.webview.send('poll');
 
-        service.timer = setTimeout(loop, delay);
+        service.timer = setTimeout(loop, service.pollDelay);
         service.lastPoll = Date.now();
       };
 

--- a/src/webview/lib/RecipeWebview.ts
+++ b/src/webview/lib/RecipeWebview.ts
@@ -58,8 +58,13 @@ class RecipeWebview {
    * Initialize the loop
    *
    * @param {Function}        Function that will be executed
+   * @param {String}          Interval which drive the loop in `ms` library format
    */
-  loop(fn) {
+  loop(fn, interval) {
+    if (interval && typeof interval === 'string') {
+      ipcRenderer.sendToHost('set-loop-delay', interval);
+    }
+
     this.loopFunc = fn;
   }
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Added the ability to change the interval which every recipe's poll function is triggered

#### Motivation and Context
On Ferdium there is an hardcoded poll interval (2s) and for some recipe are useful to give the ability to change this interval to respect and not abuse the api rate. In addition this configuration allow the reducing of the energy/resources used to run the recipe itself if the timing are correctly setted up respect of the default 2s. For compatibility if no time configuration are passed or if the time interval is less the 2s, the default value remain 2s. To configure the poll the formalism is based on the `ms` npm packages
Examples:
```js
/*Classic usage*/
...

Ferdium.loop(checkTickets); // it will use the default 2s poll interval

/*With configurable poll interval*/
...
let interval = '60s'; // can be also '1m' to specify 1 minute
Ferdium.loop(checkTickets, interval); // it will use the 60s poll interval

```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

none
