### PR TITLE
remove loading overlay

### DIFF
--- a/src/components/services/content/ServiceView.tsx
+++ b/src/components/services/content/ServiceView.tsx
@@ -14,7 +14,6 @@ import type ServiceModel from '../../../models/Service';
 import type { RealStores } from '../../../stores';
 import MediaSource from '../../MediaSource';
 import StatusBarTargetUrl from '../../ui/StatusBarTargetUrl';
-import WebviewLoader from '../../ui/WebviewLoader';
 import ServiceDisabled from './ServiceDisabled';
 import ServiceWebview from './ServiceWebview';
 import WebviewCrashHandler from './WebviewCrashHandler';
@@ -133,16 +132,8 @@ class ServiceView extends Component<IProps, IState> {
                 reload={reload}
               />
             )}
-            {service.isEnabled &&
-              service.isLoading &&
-              service.isFirstLoad &&
-              !service.isHibernating &&
-              !service.isServiceAccessRestricted && (
-                <WebviewLoader loaded={false} name={service.name} />
-              )}
             {service.isProgressbarEnabled &&
-              service.isLoadingPage &&
-              !service.isFirstLoad && <TopBarProgress />}
+              service.isLoadingPage && <TopBarProgress />}
             {service.isError && (
               <WebviewErrorHandler
                 name={service.recipe.name}


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Remove the fullscreen `WebviewLoader` modal ("Loading {service}") that appears when a service is loading for the first time. This modal blocks the entire UI and almost never dismisses after the service has finished loading due to a race condition between Electron webview events (`did-start-loading`, `did-stop-loading`, `did-frame-finish-load`).

The fix removes the `WebviewLoader` component from `ServiceView.tsx` and simplifies the `TopBarProgress` indicator to show on all page loads (not just after the first load), providing a non-blocking visual loading indicator instead.

**Changes:**
- Removed the `WebviewLoader` rendering block and its import from `ServiceView.tsx`
- Removed the `!service.isFirstLoad` condition from `TopBarProgress` so it works on all loads

#### Motivation and Context

The `WebviewLoader` fullscreen overlay depends on `service.isLoading && service.isFirstLoad` to dismiss. However, Electron's `did-start-loading` event fires multiple times (for sub-resources), resetting `isLoading = true` each time, while `did-frame-finish-load` (which sets `isFirstLoad = false`) doesn't always fire reliably for all frames. This race condition causes the modal to stay visible indefinitely, forcing users to manually reload or switch services.

The `TopBarProgress` bar already exists as an alternative loading indicator and does not block user interaction.

#### Checklist

- [x] My pull request is properly named
- [ ] The changes respect the code style of the project (`pnpm prepare-code`)
- [ ] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

fix: Remove blocking "Loading {service}" fullscreen modal that would get stuck indefinitely due to webview event race condition
