### PR TITLE
fix: tray icon broken after screen lock/unlock on GNOME Linux

### DIFF
--- a/src/lib/DBus.ts
+++ b/src/lib/DBus.ts
@@ -105,9 +105,13 @@ export default class DBus {
         oldOwner !== newOwner &&
         newOwner !== ''
       ) {
-        // Leave ample time for the StatusNotifierWatcher to be initialized
+        // StatusNotifierWatcher reappeared (e.g. screen unlock on GNOME).
+        // DO NOT destroy and recreate the tray - Electron doesn't properly
+        // clean up D-Bus exports, causing "already exported" errors.
+        // Instead, force a setImage() call which writes the icon to a new
+        // temp file and updates the IconThemePath in the D-Bus properties.
         setTimeout(() => {
-          this.trayIcon.recreateIfVisible();
+          this.trayIcon.refreshTrayAfterWatcherRestart();
         }, 400);
       }
     });

--- a/src/lib/Tray.ts
+++ b/src/lib/Tray.ts
@@ -223,6 +223,25 @@ export default class TrayIcon {
     }
   }
 
+  /**
+   * Refresh the tray icon after a StatusNotifierWatcher restart (e.g. screen
+   * unlock on GNOME). Instead of destroying and recreating the Tray object
+   * (which fails because Electron doesn't clean up D-Bus exports), we call
+   * setImage() which forces Electron to write the icon to a new temp file
+   * and update the IconThemePath property in D-Bus.
+   */
+  refreshTrayAfterWatcherRestart(): void {
+    if (!this.visible || !this.tray) {
+      return;
+    }
+
+    const icon = this._getAsset(
+      'tray',
+      this._getAssetFromIndicator(this.indicator),
+    );
+    this.tray.setImage(icon);
+  }
+
   setIndicator(indicator: string | number): void {
     this.indicator = indicator;
     this._refreshIcon();


### PR DESCRIPTION
## Summary

Fixes the tray icon becoming a broken/generic placeholder after locking and unlocking the screen on GNOME Linux with the AppIndicator extension.

## Root Cause

When the screen is locked on GNOME, the `StatusNotifierWatcher` D-Bus service restarts. The previous code responded by destroying and recreating the `Tray` object (`recreateIfVisible()`). This failed for two reasons:

1. **Temp files deleted**: Electron stores tray icon images in temporary files under `/tmp/.org.chromium.Chromium.*/`. These files are deleted during the lock/unlock cycle, so the `IconThemePath` registered in D-Bus points to a non-existent directory.

2. **D-Bus exports not cleaned up**: When `tray.destroy()` is called, Electron does not properly clean up the D-Bus method exports (`StatusNotifierItem.Activate`, etc.). Creating a new `Tray` then fails silently with `"already exported"` errors, resulting in no icon or a broken icon.

## Fix

Instead of destroying and recreating the `Tray`, we now call `setImage()` on the **existing** `Tray` object when the `StatusNotifierWatcher` reappears. This forces Electron to:
- Write the icon to a **new** temp file
- Update the `IconThemePath` property in D-Bus

This approach avoids both the stale temp file issue and the D-Bus export cleanup bug.

## Changes

- **`src/lib/DBus.ts`**: Call `refreshTrayAfterWatcherRestart()` instead of `recreateIfVisible()` when the StatusNotifierWatcher reappears
- **`src/lib/Tray.ts`**: Add `refreshTrayAfterWatcherRestart()` method that calls `setImage()` on the existing tray

## Testing

1. Open Ferdium on GNOME Linux with AppIndicator extension
2. Verify the tray icon appears correctly
3. Lock the screen (Super+L)
4. Unlock the screen
5. Verify the tray icon is still correct (not a broken placeholder)
6. Repeat multiple times to confirm stability