### PR TITLE
fix: removing will-navigate UA switch that cancelled SAML POST navigations

### DIFF
--- a/src/models/UserAgent.ts
+++ b/src/models/UserAgent.ts
@@ -7,9 +7,6 @@ const debug = require('../preload-safe-debug')('Ferdium:UserAgent');
 
 export default class UserAgent {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _willNavigateListener = (_event: any): void => {};
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _didNavigateListener = (_event: any): void => {};
 
   @observable.ref webview: ElectronWebView = null;
@@ -78,26 +75,23 @@ export default class UserAgent {
   @action _handleNavigate(url: string): void {
     if (url.startsWith('https://accounts.google.com')) {
       debug('Setting user agent to chromeless for url', url);
-      // Set chromeless user agent (without Chrome version) for Google accounts
+      // Set chromeless user agent (without Chrome version) for Google accounts.
+      // Note: This is intentionally only called from did-navigate (after navigation
+      // completes), never from will-navigate or did-redirect-navigation. Setting
+      // webview.userAgent during a pending navigation or redirect chain causes
+      // Electron to cancel the navigation via SetUserAgentOverride(), which breaks
+      // cross-origin form POST requests (e.g. SAML ACS endpoints) and redirect chains.
       this.webview.userAgent =
         this.serviceUserAgentPref || this.userAgentWithoutChromeVersion;
     } else {
       debug('Setting user agent to default for url', url);
-      // Set default user agent for all other sites
       this.webview.userAgent =
         this.serviceUserAgentPref || this.defaultUserAgent;
     }
-    // Note: We don't reload the URL here (previously done with loadURL() on will-navigate)
-    // because it cancels POST requests, which breaks SSO/SAML authentication flows
-    // (e.g., ACS endpoint requests). The user agent change takes effect on the
-    // current navigation without needing a reload.
   }
 
   _addWebviewEvents(webview: ElectronWebView): void {
     debug('Adding event handlers');
-
-    this._willNavigateListener = event => this._handleNavigate(event.url);
-    webview.addEventListener('will-navigate', this._willNavigateListener);
 
     this._didNavigateListener = event => this._handleNavigate(event.url);
     webview.addEventListener('did-navigate', this._didNavigateListener);
@@ -106,7 +100,6 @@ export default class UserAgent {
   _removeWebviewEvents(webview: ElectronWebView): void {
     debug('Removing event handlers');
 
-    webview.removeEventListener('will-navigate', this._willNavigateListener);
     webview.removeEventListener('did-navigate', this._didNavigateListener);
   }
 }


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Setting webview.userAgent in the will-navigate handler calls SetUserAgentOverride() in Electron while a navigation is pending, which cancels the navigation. This broke any cross-origin form POST to accounts.google.com, including SAML ACS endpoints such as /o/saml2/continue and /samlrp/.../acs.

Fix by removing the will-navigate listener entirely and updating the user agent only in did-navigate, after navigation completes. The chromeless UA behaviour for Google accounts is preserved; it now takes effect on subsequent requests from the loaded page rather than on the navigation itself.


#### Motivation and Context

PR #2261 didn't address all edge cases seen in #1973

When logging in with my a new to me SSO provider, login works fine but at the end, it fails just returning a blank screen with the following sort of message:

```
No flow state available TransactionId: prd-4.0.1+1015010-ACC_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

The `will-navigate` handler was calling `_handleNavigate` for every navigation on every service, not just Google ones. For any non-Google URL, `_handleNavigate` would call `this.webview.userAgent = this.serviceUserAgentPref || this.defaultUserAgent`, setting it to whatever the current UA already was. But even setting the UA to the same value calls `SetUserAgentOverride()` in Electron, which cancels any pending navigation.

This means the will-navigate bug was silently breaking any cross-origin form POST on any service — Okta SAML, ADFS, Microsoft SSO, payment gateways, etc. The fix benefits all of them, not just Google.


Fix 1 (PR #2261): Removed loadURL(url) from will-navigate because it was aborting SAML POST requests. The chromelessUserAgent flag was also removed at the same time, replaced with unconditional webview.userAgent = on every will-navigate. This stripped the accidental protection: now UA assignment fires on every single navigation, including mid-SAML-flow.

Fix 2 (this PR): Removed will-navigate entirely. Now UA is only set in did-navigate, which fires after the navigation is fully committed at that point IsLoadingIncludingInnerFrameTrees() is false, so SetUserAgentOverride can't trigger a reload. I believe this is the correct and permanent fix.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`pnpm prepare-code`)
- [X] `pnpm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes

removing will-navigate UA switch that cancelled SAML POST navigations to fix additional issues #2261 aimed to fix