### PR TITLE
Fix tab border active on horizontal layout

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -97,7 +97,7 @@ const generateAccentStyle = (accentColorStr, useHorizontalStyle) => {
       border-right-color: ${accentColorStr};
     }
 
-    .franz-form .franz-form__radio.is-selected, .tab-item.is-active {
+    .franz-form .franz-form__radio.is-selected {
       box-shadow: inset ${useHorizontalStyle ? '0 4px' : '4px 0'} 0 0 ${accentColorStr};
     }
 
@@ -131,6 +131,7 @@ const generateAccentStyle = (accentColorStr, useHorizontalStyle) => {
 
     .tab-item.is-active {
       background: ${accentColor.lightness(90).hex()};
+      box-shadow: inset ${useHorizontalStyle ? '0 4px' : '4px 0'} 0 0 ${accentColorStr};
     }
   `;
 };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Fix horizontal layout border position for active service

#### Motivation and Context
This small PR fixes the active service border indicator on the horizontal layout of the sidebar

#### Screenshots
Before:
<img width="148" height="79" alt="image" src="https://github.com/user-attachments/assets/7d58d6e5-66a6-4279-bc6f-9402c2de7bfa" />

After:
<img width="155" height="85" alt="image" src="https://github.com/user-attachments/assets/7075eb06-ef6b-4fcd-84b1-fe36d232b31e" />


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fixed horizontal layout border position for active service
<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
