### PR TITLE
fix: open OAuth popups in-app to preserve window.opener for auth callbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,9 +309,31 @@ const createWindow = () => {
         });
       }
 
-      contents.setWindowOpenHandler(({ url }) => {
+      contents.setWindowOpenHandler(({ url, disposition }) => {
+        // OAuth popups (Google, Microsoft, etc.) are opened via window.open()
+        // and need window.opener preserved so the parent can receive the
+        // postMessage callback that completes the flow. Allow them as a child
+        // BrowserWindow that inherits the service partition.
+        if (disposition === 'new-window') {
+          return {
+            action: 'allow',
+            outlivesOpener: false,
+            overrideBrowserWindowOptions: {
+              parent: mainWindow,
+              fullscreenable: false,
+              webPreferences: { session: contents.session },
+            },
+          };
+        }
+
+        // Regular link clicks → open in the user's default browser.
         openExternalUrl(url);
         return { action: 'deny' };
+      });
+
+      contents.on('did-create-window', child => {
+        enableWebContents(child.webContents);
+        child.webContents.setWebRTCIPHandlingPolicy(webRTCIPHandlingPolicy);
       });
 
       // Handle will download event from main process (prevent download dialog)


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Make the webview-level ``setWindowOpenHandler`` in ``src/index.ts`` disposition-aware:

- ``disposition === 'new-window'`` (i.e. ``window.open()`` from JavaScript, the disposition used by OAuth popups): allow the popup as a child ``BrowserWindow`` that inherits the service ``session``, with ``parent: mainWindow``, ``fullscreenable: false`` and ``outlivesOpener: false``. This preserves ``window.opener`` so the parent page can receive the ``postMessage`` callback that completes the auth flow, and keeps the popup on the same partition so cookies are shared with the service.
- ``foreground-tab`` / ``background-tab`` (regular link clicks, ``target=_blank``, ctrl-click): unchanged — keep handing off to ``openExternalUrl`` so links open in the user's default browser.

A ``did-create-window`` listener is added so popups call ``enableWebContents`` and inherit ``webRTCIPHandlingPolicy``, mirroring the existing ``open-browser-window`` IPC path (``src/index.ts:679-680``).

#### Motivation and Context

The previous handler was unconditional: every ``window.open`` from a service was sent to the OS default browser via ``openExternalUrl``. That works for plain link clicks, but breaks any OAuth/SSO flow that opens a popup expecting ``window.opener.postMessage`` to deliver the result back to the service — the popup ended up in the system browser and the callback never reached the original webview. Users typically saw two windows opening (one external, one stale) and the service hung at the login step.

Likely fixes / closely related to:
- #2273 — Google secured log-in is not working! (Any.do and ClickUp tested)
- #1008 — [Bug]: ClickUp unable to SSO
- #1420 — Rocket.Chat oAuth window opens in browser
- #634 — Figma doesn't login with Google SSO either as the Service or as a Custom Website

This is independent from #2261 / #2396, which addressed a separate User-Agent override issue that was cancelling SAML POST navigations.

#### Screenshots

n/a

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (``pnpm prepare-code``)
- [x] ``pnpm test`` passes
- [x] I tested/previewed my changes locally — verified ClickUp "Continue with Google" now opens a single in-app popup, completes login, popup closes itself, and the service is left logged in. Verified plain link clicks still open in the default browser.

#### Release Notes

Fix in-app OAuth popups (Google SSO and similar) for ClickUp and other services that rely on ``window.opener.postMessage`` callbacks.