### PR TITLE
Quality: Deprecated react-jss HOCs should be migrated to hooks

### DIFF
--- a/src/components/ui/error/index.tsx
+++ b/src/components/ui/error/index.tsx
@@ -1,6 +1,6 @@
 import type { Classes } from 'jss';
 import { Component } from 'react';
-import injectSheet from 'react-jss';
+import { useStyles } from 'react-jss';
 
 import styles from './styles';
 
@@ -9,12 +9,10 @@ interface IProps {
   message: string;
 }
 
-class ErrorComponent extends Component<IProps> {
-  render() {
-    const { classes, message } = this.props;
+function ErrorComponent({ classes, message }: IProps) {
+  useStyles(styles);
 
-    return <p className={classes.message}>{message}</p>;
-  }
+  return <p className={classes.message}>{message}</p>;
 }
 
-export default injectSheet(styles, { injectTheme: true })(ErrorComponent);
+export default ErrorComponent;


### PR DESCRIPTION
## Summary

Quality: Deprecated react-jss HOCs should be migrated to hooks

## Problem

**Severity**: `Medium` | **File**: `src/components/ui/error/index.tsx:L41`

Multiple components use deprecated HOCs like injectSheet, injectStyle, withStyles from react-jss. These should be migrated to useStyles hook for React 17+ compatibility.

## Solution

Migrate from injectSheet to useStyles hook: import { useStyles } from 'react-jss';

## Changes

- `src/components/ui/error/index.tsx` (modified)