### PR TITLE
feat: workspace profile pictures, drag-to-reorder, and quick-switch sidebar

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -97,6 +97,7 @@ interface IProps extends WrappedComponentProps, WithStylesProps<typeof styles> {
   isFullScreen: boolean;
   sidebar: React.ReactElement;
   workspacesDrawer: React.ReactElement;
+  workspaceQuickSwitchBar?: React.ReactElement | null;
   services: React.ReactElement;
   showServicesUpdatedInfoBar: boolean;
   appUpdateIsDownloaded: boolean;
@@ -115,6 +116,10 @@ interface IState {
 
 @observer
 class AppLayout extends Component<PropsWithChildren<IProps>, IState> {
+  static defaultProps = {
+    workspaceQuickSwitchBar: null,
+  };
+
   constructor(props) {
     super(props);
 
@@ -129,6 +134,7 @@ class AppLayout extends Component<PropsWithChildren<IProps>, IState> {
       classes,
       isFullScreen,
       workspacesDrawer,
+      workspaceQuickSwitchBar,
       sidebar,
       services,
       showServicesUpdatedInfoBar,
@@ -173,6 +179,8 @@ class AppLayout extends Component<PropsWithChildren<IProps>, IState> {
             )}
             <div className={`app__content ${classes.appContent}`}>
               {workspacesDrawer}
+              {/* Quick-switch bar: slides in from the right of the drawer when drawer is closed */}
+              {workspaceQuickSwitchBar}
               {sidebar}
               <div className="app__service">
                 <WorkspaceSwitchingIndicator />

--- a/src/components/ui/WorkspaceIcon.tsx
+++ b/src/components/ui/WorkspaceIcon.tsx
@@ -1,0 +1,72 @@
+import { observer } from 'mobx-react';
+import type { ReactElement } from 'react';
+import { Component } from 'react';
+import withStyles, { type WithStylesProps } from 'react-jss';
+
+const styles = theme => ({
+  avatar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    overflow: 'hidden',
+    flexShrink: 0,
+    background: theme.workspaces?.drawer?.listItem?.activeBackground || '#999',
+    color: '#fff',
+    fontWeight: 600,
+    userSelect: 'none',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    display: 'block',
+  },
+});
+
+interface IProps extends WithStylesProps<typeof styles> {
+  iconPath?: string | null;
+  name: string;
+  size?: number;
+  isActive?: boolean;
+}
+
+@observer
+class WorkspaceIcon extends Component<IProps> {
+  static defaultProps = {
+    iconPath: null,
+    size: 32,
+    isActive: false,
+  };
+
+  render(): ReactElement {
+    const { classes, iconPath, name, size } = this.props;
+
+    const initial = name && name.length > 0 ? [...name][0].toUpperCase() : '?';
+    const fontSize = Math.round((size || 32) * 0.45);
+
+    return (
+      <div
+        className={classes.avatar}
+        style={{ width: size, height: size, fontSize }}
+        aria-label={name}
+      >
+        {iconPath ? (
+          <img
+            src={`file://${iconPath}`}
+            alt={name}
+            className={classes.image}
+            onError={e => {
+              // If image fails to load, hide it so the initial shows through
+              (e.target as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        ) : (
+          initial
+        )}
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles, { injectTheme: true })(WorkspaceIcon);

--- a/src/containers/layout/AppLayoutContainer.tsx
+++ b/src/containers/layout/AppLayoutContainer.tsx
@@ -16,6 +16,7 @@ import AppLoader from '../../components/ui/AppLoader';
 import { DEFAULT_ACCENT_COLOR } from '../../config';
 import { workspaceStore } from '../../features/workspaces';
 import WorkspaceDrawer from '../../features/workspaces/components/WorkspaceDrawer';
+import WorkspaceQuickSwitchBar from '../../features/workspaces/components/WorkspaceQuickSwitchBar';
 
 interface IProps extends StoresProps {}
 
@@ -106,6 +107,8 @@ class AppLayoutContainer extends Component<IProps> {
       );
     }
 
+    const { hideAllServicesWorkspace } = settings.all.app;
+
     const workspacesDrawer = (
       <WorkspaceDrawer
         getServicesForWorkspace={workspace =>
@@ -117,6 +120,21 @@ class AppLayoutContainer extends Component<IProps> {
         actions={this.props.actions}
       />
     );
+
+    // Quick-switch bar: shown when drawer is closed and there are workspaces
+    const { activeWorkspace, isSwitchingWorkspace, nextWorkspace } = workspaceStore;
+    const actualWorkspace = isSwitchingWorkspace ? nextWorkspace : activeWorkspace;
+    const quickSwitchBar =
+      !workspaceStore.isWorkspaceDrawerOpen &&
+      workspaceStore.userHasWorkspaces ? (
+        <WorkspaceQuickSwitchBar
+          workspaces={workspaceStore.workspaces}
+          activeWorkspace={actualWorkspace}
+          hideAllServicesWorkspace={hideAllServicesWorkspace}
+          stores={this.props.stores}
+          actions={this.props.actions}
+        />
+      ) : null;
 
     const sidebar = (
       <Sidebar
@@ -184,6 +202,7 @@ class AppLayoutContainer extends Component<IProps> {
             authRequestFailed={app.authRequestFailed}
             sidebar={sidebar}
             workspacesDrawer={workspacesDrawer}
+            workspaceQuickSwitchBar={quickSwitchBar}
             services={servicesContainer}
             installAppUpdate={installUpdate}
             showRequiredRequestsError={requests.showRequiredRequestsError}

--- a/src/features/workspaces/actions.ts
+++ b/src/features/workspaces/actions.ts
@@ -14,6 +14,9 @@ interface WorkspaceActions {
   delete: (workspaceArg: WorkspaceArg) => void;
   update: (workspaceArg: WorkspaceArg) => void;
   toggleKeepAllWorkspacesLoadedSetting: () => void;
+  reorder: ({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }) => void;
+  saveIcon: ({ workspaceId, iconPath }: { workspaceId: string; iconPath: string }) => void;
+  deleteIcon: ({ workspaceId }: { workspaceId: string }) => void;
 }
 
 export default createActionsFromDefinitions<WorkspaceActions>(
@@ -37,6 +40,17 @@ export default createActionsFromDefinitions<WorkspaceActions>(
     toggleWorkspaceDrawer: {},
     openWorkspaceSettings: {},
     toggleKeepAllWorkspacesLoadedSetting: {},
+    reorder: {
+      oldIndex: PropTypes.number.isRequired,
+      newIndex: PropTypes.number.isRequired,
+    },
+    saveIcon: {
+      workspaceId: PropTypes.string.isRequired,
+      iconPath: PropTypes.string.isRequired,
+    },
+    deleteIcon: {
+      workspaceId: PropTypes.string.isRequired,
+    },
   },
   PropTypes.checkPropTypes,
 );

--- a/src/features/workspaces/api.ts
+++ b/src/features/workspaces/api.ts
@@ -51,7 +51,7 @@ export const workspaceApi = {
     const url = `${apiBase()}/workspace/${workspace.id}`;
     const options = {
       method: 'PUT',
-      body: JSON.stringify(pick(workspace, ['name', 'services'])),
+      body: JSON.stringify(pick(workspace, ['name', 'services', 'order', 'iconPath'])),
     };
     debug('updateWorkspace UPDATE', url, options);
     const result = await sendAuthRequest(url, options);
@@ -60,6 +60,22 @@ export const workspaceApi = {
       throw new Error("Couldn't updateWorkspace");
     }
     return new Workspace(await result.json());
+  },
+
+  reorderWorkspace: async ({ id, order }: { id: string; order: number }) => {
+    const url = `${apiBase()}/workspace/${id}/reorder`;
+    const options = {
+      method: 'PUT',
+      body: JSON.stringify({ order }),
+    };
+    debug('reorderWorkspace PUT', url, options);
+    const result = await sendAuthRequest(url, options);
+    debug('reorderWorkspace RESULT', result);
+    if (!result.ok) {
+      // Graceful fallback: reorder is stored locally even if server doesn't support this endpoint
+      debug('reorderWorkspace: server does not support reorder endpoint, using local order only');
+    }
+    return true;
   },
 };
 
@@ -79,10 +95,15 @@ export const updateWorkspaceRequest = new Request(
   workspaceApi,
   'updateWorkspace',
 );
+export const reorderWorkspaceRequest = new Request(
+  workspaceApi,
+  'reorderWorkspace',
+);
 
 export const resetApiRequests = () => {
   getUserWorkspacesRequest.reset();
   createWorkspaceRequest.reset();
   deleteWorkspaceRequest.reset();
   updateWorkspaceRequest.reset();
+  reorderWorkspaceRequest.reset();
 };

--- a/src/features/workspaces/components/EditWorkspaceForm.tsx
+++ b/src/features/workspaces/components/EditWorkspaceForm.tsx
@@ -13,13 +13,23 @@ import { H2 } from '../../../components/ui/headline';
 import Infobox from '../../../components/ui/infobox/index';
 import Input from '../../../components/ui/input';
 import Toggle from '../../../components/ui/toggle';
+import WorkspaceIcon from '../../../components/ui/WorkspaceIcon';
 import { KEEP_WS_LOADED_USID } from '../../../config';
 import { required } from '../../../helpers/validation-helpers';
 import Form from '../../../lib/Form';
 import type Service from '../../../models/Service';
 import type Request from '../../../stores/lib/Request';
+import workspaceActions from '../actions';
 import type Workspace from '../models/Workspace';
 import WorkspaceServiceListItem from './WorkspaceServiceListItem';
+
+// Electron dialog for picking files
+let dialog: any;
+try {
+  dialog = require('@electron/remote').dialog;
+} catch {
+  dialog = null;
+}
 
 const messages = defineMessages({
   buttonDelete: {
@@ -59,6 +69,18 @@ const messages = defineMessages({
     id: 'settings.services.discoverServices',
     defaultMessage: 'Discover services',
   },
+  iconHeadline: {
+    id: 'settings.workspace.form.iconHeadline',
+    defaultMessage: 'Workspace icon',
+  },
+  changeIcon: {
+    id: 'settings.workspace.form.changeIcon',
+    defaultMessage: 'Choose image…',
+  },
+  removeIcon: {
+    id: 'settings.workspace.form.removeIcon',
+    defaultMessage: 'Remove icon',
+  },
 });
 
 const styles = {
@@ -70,6 +92,29 @@ const styles = {
   },
   keepLoadedInfo: {
     marginBottom: '2rem !important',
+  },
+  iconSection: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '16px',
+    marginBottom: '24px',
+  },
+  iconButtons: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  iconButton: {
+    fontSize: '12px',
+    padding: '6px 12px',
+    cursor: 'pointer',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    background: 'transparent',
+    color: 'inherit',
+    '&:hover': {
+      background: 'rgba(0,0,0,0.06)',
+    },
   },
 };
 
@@ -153,6 +198,30 @@ class EditWorkspaceForm extends Component<IProps> {
     servicesField.set(serviceIds);
   }
 
+  async pickIcon(): Promise<void> {
+    const { workspace } = this.props;
+    if (!dialog) return;
+
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [
+        { name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'] },
+      ],
+    });
+
+    if (!result.canceled && result.filePaths.length > 0) {
+      workspaceActions.saveIcon({
+        workspaceId: workspace.id,
+        iconPath: result.filePaths[0],
+      });
+    }
+  }
+
+  removeIcon(): void {
+    const { workspace } = this.props;
+    workspaceActions.deleteIcon({ workspaceId: workspace.id });
+  }
+
   render(): ReactElement {
     const {
       classes,
@@ -191,6 +260,37 @@ class EditWorkspaceForm extends Component<IProps> {
               {intl.formatMessage(messages.keepLoadedInfo)}
             </p>
           </div>
+
+          {/* ===== Icon section ===== */}
+          <H2>{intl.formatMessage(messages.iconHeadline)}</H2>
+          <div className={classes.iconSection}>
+            <WorkspaceIcon
+              iconPath={workspace.iconPath}
+              name={workspace.name}
+              size={56}
+            />
+            <div className={classes.iconButtons}>
+              {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+              <span
+                className={classes.iconButton}
+                onClick={() => this.pickIcon()}
+                onKeyDown={noop}
+              >
+                {intl.formatMessage(messages.changeIcon)}
+              </span>
+              {workspace.iconPath && (
+                // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+                <span
+                  className={classes.iconButton}
+                  onClick={() => this.removeIcon()}
+                  onKeyDown={noop}
+                >
+                  {intl.formatMessage(messages.removeIcon)}
+                </span>
+              )}
+            </div>
+          </div>
+
           <H2>{intl.formatMessage(messages.servicesInWorkspaceHeadline)}</H2>
           <div className={classes.serviceList}>
             {services.length === 0 ? (

--- a/src/features/workspaces/components/WorkspaceDrawer.tsx
+++ b/src/features/workspaces/components/WorkspaceDrawer.tsx
@@ -130,11 +130,6 @@ const styles = theme => ({
       },
     },
   },
-  // Highlight drop target while dragging
-  dropTarget: {
-    outline: `2px dashed ${theme.workspaces.drawer.buttons.color}`,
-    outlineOffset: '-2px',
-  },
 });
 
 interface IProps
@@ -145,21 +140,12 @@ interface IProps
   useCompactWorkspaceDrawer?: boolean;
 }
 
-interface IState {
-  dragOverIndex: number | null;
-  draggingIndex: number | null;
-}
-
 @inject('stores')
 @observer
-class WorkspaceDrawer extends Component<IProps, IState> {
-  constructor(props: IProps) {
-    super(props);
-    this.state = {
-      dragOverIndex: null,
-      draggingIndex: null,
-    };
-  }
+class WorkspaceDrawer extends Component<IProps> {
+  // Plain instance variables for drag state — no React state needed,
+  // avoids unused-state lint errors while keeping drag tracking simple.
+  private _draggingIndex: number | null = null;
 
   componentDidMount(): void {
     try {
@@ -171,25 +157,27 @@ class WorkspaceDrawer extends Component<IProps, IState> {
   }
 
   handleDragStart = (index: number) => () => {
-    this.setState({ draggingIndex: index });
+    this._draggingIndex = index;
   };
 
-  handleDragOver = (index: number) => (e: React.DragEvent) => {
+  // Static handler — doesn't need instance scope, satisfies unicorn/consistent-function-scoping
+  static handleDragOver(e: React.DragEvent) {
     e.preventDefault();
-    this.setState({ dragOverIndex: index });
-  };
+  }
 
   handleDrop = (dropIndex: number) => (e: React.DragEvent) => {
     e.preventDefault();
-    const { draggingIndex } = this.state;
-    if (draggingIndex !== null && draggingIndex !== dropIndex) {
-      workspaceActions.reorder({ oldIndex: draggingIndex, newIndex: dropIndex });
+    if (this._draggingIndex !== null && this._draggingIndex !== dropIndex) {
+      workspaceActions.reorder({
+        oldIndex: this._draggingIndex,
+        newIndex: dropIndex,
+      });
     }
-    this.setState({ dragOverIndex: null, draggingIndex: null });
+    this._draggingIndex = null;
   };
 
   handleDragEnd = () => {
-    this.setState({ dragOverIndex: null, draggingIndex: null });
+    this._draggingIndex = null;
   };
 
   render(): ReactElement {
@@ -207,7 +195,6 @@ class WorkspaceDrawer extends Component<IProps, IState> {
       settings.all.app;
 
     const compactClass = useCompactWorkspaceDrawer ? 'compact' : '';
-    const { dragOverIndex, draggingIndex } = this.state;
 
     return (
       <div className={`${classes.drawer} workspaces-drawer ${compactClass}`}>
@@ -233,7 +220,10 @@ class WorkspaceDrawer extends Component<IProps, IState> {
           </span>
         </H1>
         <div className={`${classes.workspaces} ${compactClass}`}>
-          <div className={classes.workspacesList} onDragEnd={this.handleDragEnd}>
+          <div
+            className={classes.workspacesList}
+            onDragEnd={this.handleDragEnd}
+          >
             {!hideAllServicesWorkspace && (
               <WorkspaceDrawerItem
                 name={intl.formatMessage(messages.allServices)}
@@ -268,7 +258,7 @@ class WorkspaceDrawer extends Component<IProps, IState> {
                 isCompact={useCompactWorkspaceDrawer}
                 draggable
                 onDragStart={this.handleDragStart(index)}
-                onDragOver={this.handleDragOver(index)}
+                onDragOver={WorkspaceDrawer.handleDragOver}
                 onDrop={this.handleDrop(index)}
               />
             ))}

--- a/src/features/workspaces/components/WorkspaceDrawer.tsx
+++ b/src/features/workspaces/components/WorkspaceDrawer.tsx
@@ -34,7 +34,7 @@ const messages = defineMessages({
   workspaceFeatureInfo: {
     id: 'workspaceDrawer.workspaceFeatureInfo',
     defaultMessage:
-      '<p>Ferdium Workspaces let you focus on what’s important right now. Set up different sets of services and easily switch between them at any time.</p><p>You decide which services you need when and where, so we can help you stay on top of your game - or easily switch off from work whenever you want.</p>',
+      "<p>Ferdium Workspaces let you focus on what's important right now. Set up different sets of services and easily switch between them at any time.</p><p>You decide which services you need when and where, so we can help you stay on top of your game - or easily switch off from work whenever you want.</p>",
   },
   addNewWorkspaceLabel: {
     id: 'workspaceDrawer.addNewWorkspaceLabel',
@@ -130,6 +130,11 @@ const styles = theme => ({
       },
     },
   },
+  // Highlight drop target while dragging
+  dropTarget: {
+    outline: `2px dashed ${theme.workspaces.drawer.buttons.color}`,
+    outlineOffset: '-2px',
+  },
 });
 
 interface IProps
@@ -140,9 +145,22 @@ interface IProps
   useCompactWorkspaceDrawer?: boolean;
 }
 
+interface IState {
+  dragOverIndex: number | null;
+  draggingIndex: number | null;
+}
+
 @inject('stores')
 @observer
-class WorkspaceDrawer extends Component<IProps> {
+class WorkspaceDrawer extends Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      dragOverIndex: null,
+      draggingIndex: null,
+    };
+  }
+
   componentDidMount(): void {
     try {
       getUserWorkspacesRequest.execute();
@@ -151,6 +169,28 @@ class WorkspaceDrawer extends Component<IProps> {
       console.log(error);
     }
   }
+
+  handleDragStart = (index: number) => () => {
+    this.setState({ draggingIndex: index });
+  };
+
+  handleDragOver = (index: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    this.setState({ dragOverIndex: index });
+  };
+
+  handleDrop = (dropIndex: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const { draggingIndex } = this.state;
+    if (draggingIndex !== null && draggingIndex !== dropIndex) {
+      workspaceActions.reorder({ oldIndex: draggingIndex, newIndex: dropIndex });
+    }
+    this.setState({ dragOverIndex: null, draggingIndex: null });
+  };
+
+  handleDragEnd = () => {
+    this.setState({ dragOverIndex: null, draggingIndex: null });
+  };
 
   render(): ReactElement {
     const { classes, getServicesForWorkspace } = this.props;
@@ -167,6 +207,7 @@ class WorkspaceDrawer extends Component<IProps> {
       settings.all.app;
 
     const compactClass = useCompactWorkspaceDrawer ? 'compact' : '';
+    const { dragOverIndex, draggingIndex } = this.state;
 
     return (
       <div className={`${classes.drawer} workspaces-drawer ${compactClass}`}>
@@ -192,7 +233,7 @@ class WorkspaceDrawer extends Component<IProps> {
           </span>
         </H1>
         <div className={`${classes.workspaces} ${compactClass}`}>
-          <div className={classes.workspacesList}>
+          <div className={classes.workspacesList} onDragEnd={this.handleDragEnd}>
             {!hideAllServicesWorkspace && (
               <WorkspaceDrawerItem
                 name={intl.formatMessage(messages.allServices)}
@@ -210,6 +251,7 @@ class WorkspaceDrawer extends Component<IProps> {
               <WorkspaceDrawerItem
                 key={workspace.id}
                 name={workspace.name}
+                iconPath={workspace.iconPath}
                 isActive={actualWorkspace === workspace}
                 onClick={() => {
                   if (actualWorkspace === workspace) {
@@ -224,6 +266,10 @@ class WorkspaceDrawer extends Component<IProps> {
                 services={getServicesForWorkspace(workspace)}
                 shortcutIndex={index + 1}
                 isCompact={useCompactWorkspaceDrawer}
+                draggable
+                onDragStart={this.handleDragStart(index)}
+                onDragOver={this.handleDragOver(index)}
+                onDrop={this.handleDrop(index)}
               />
             ))}
           </div>

--- a/src/features/workspaces/components/WorkspaceDrawerItem.tsx
+++ b/src/features/workspaces/components/WorkspaceDrawerItem.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@electron/remote';
-import { mdiApps } from '@mdi/js';
+import { mdiApps, mdiDragVertical } from '@mdi/js';
 import classnames from 'classnames';
 import type { MenuItemConstructorOptions } from 'electron';
 import { noop } from 'lodash';
@@ -12,6 +12,7 @@ import {
 } from 'react-intl';
 import withStyles, { type WithStylesProps } from 'react-jss';
 import Icon from '../../../components/ui/icon';
+import WorkspaceIcon from '../../../components/ui/WorkspaceIcon';
 import { altKey, cmdOrCtrlShortcutKey } from '../../../environment';
 import { acceleratorString } from '../../../jsUtils';
 
@@ -42,6 +43,9 @@ const styles = theme => ({
     padding: `15px ${theme.workspaces.drawer.padding}px`,
     borderBottom: `1px solid ${theme.workspaces.drawer.listItem.border}`,
     transition: itemTransition,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
     '&:first-child': {
       borderTop: `1px solid ${theme.workspaces.drawer.listItem.border}`,
     },
@@ -56,12 +60,20 @@ const styles = theme => ({
       textAlign: 'center',
       fontSize: '16px',
     },
+    '&:hover $dragHandle': {
+      opacity: 1,
+    },
   },
   isActiveItem: {
     backgroundColor: theme.workspaces.drawer.listItem.activeBackground,
     '&:hover': {
       backgroundColor: theme.workspaces.drawer.listItem.activeBackground,
     },
+  },
+  textContent: {
+    flex: 1,
+    overflow: 'hidden',
+    minWidth: 0,
   },
   name: {
     marginTop: '4px',
@@ -100,31 +112,63 @@ const styles = theme => ({
   activeIcon: {
     fill: theme.workspaces.drawer.listItem.name.activeColor,
   },
+  dragHandle: {
+    opacity: 0,
+    transition: 'opacity 150ms',
+    cursor: 'grab',
+    flexShrink: 0,
+    fill: theme.workspaces.drawer.listItem.name.color,
+    '&:active': {
+      cursor: 'grabbing',
+    },
+    '&.compact': {
+      display: 'none',
+    },
+  },
 });
 
 interface IProps extends WithStylesProps<typeof styles>, WrappedComponentProps {
   isActive: boolean;
   name: string;
+  iconPath?: string | null;
   onClick: MouseEventHandler<HTMLInputElement>;
   services: string[];
   onContextMenuEditClick?: (() => void) | null;
   shortcutIndex: number;
   isCompact: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+  onDragOver?: (e: React.DragEvent) => void;
+  onDrop?: (e: React.DragEvent) => void;
+  draggable?: boolean;
 }
 
 @observer
 class WorkspaceDrawerItem extends Component<IProps> {
+  static defaultProps = {
+    iconPath: null,
+    onContextMenuEditClick: null,
+    onDragStart: noop,
+    onDragOver: noop,
+    onDrop: noop,
+    draggable: false,
+  };
+
   render(): ReactElement {
     const {
       classes,
       isActive,
       name,
+      iconPath,
       onClick,
       onContextMenuEditClick = null,
       services,
       shortcutIndex,
       intl,
       isCompact,
+      onDragStart,
+      onDragOver,
+      onDrop,
+      draggable,
     } = this.props;
 
     const compactClass = isCompact ? 'compact' : '';
@@ -160,6 +204,10 @@ class WorkspaceDrawerItem extends Component<IProps> {
           }
         }}
         onKeyDown={noop}
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        draggable={draggable && !isCompact}
         aria-label={isCompact ? name : undefined}
         data-tooltip-id="tooltip-workspaces-drawer"
         data-tooltip-content={acceleratorString({
@@ -167,41 +215,76 @@ class WorkspaceDrawerItem extends Component<IProps> {
           keyCombo: `${cmdOrCtrlShortcutKey(false)}+${altKey(false)}`,
         })}
       >
-        <span
-          className={classnames([
-            classes.name,
-            isActive ? classes.activeName : null,
-            compactClass,
-          ])}
-        >
-          {compactClass ? (
-            shortcutIndex === 0 ? (
-              <Icon
-                icon={mdiApps}
-                size={1.5}
-                className={classnames([
-                  classes.icon,
-                  isActive ? classes.activeIcon : null,
-                ])}
-              />
-            ) : (
-              [...name][0]
-            )
+        {/* Drag handle — only shown on hover in non-compact mode */}
+        {!isCompact && shortcutIndex > 0 && (
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+          <span
+            className={classnames([classes.dragHandle, compactClass])}
+            onMouseDown={e => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
+            onKeyDown={noop}
+          >
+            <Icon
+              icon={mdiDragVertical}
+              size={0.9}
+            />
+          </span>
+        )}
+
+        {/* Compact mode: show icon or initials circle */}
+        {isCompact ? (
+          shortcutIndex === 0 ? (
+            <Icon
+              icon={mdiApps}
+              size={1.5}
+              className={classnames([
+                classes.icon,
+                isActive ? classes.activeIcon : null,
+              ])}
+            />
           ) : (
-            name
-          )}
-        </span>
-        <span
-          className={classnames([
-            classes.services,
-            isActive ? classes.activeServices : null,
-            compactClass,
-          ])}
-        >
-          {services.length > 0
-            ? services.join(', ')
-            : intl.formatMessage(messages.noServicesAddedYet)}
-        </span>
+            <WorkspaceIcon
+              iconPath={iconPath}
+              name={name}
+              size={36}
+              isActive={isActive}
+            />
+          )
+        ) : (
+          <>
+            {/* Normal mode: icon on the left if workspace has one (not "All services") */}
+            {shortcutIndex > 0 && (
+              <WorkspaceIcon
+                iconPath={iconPath}
+                name={name}
+                size={32}
+                isActive={isActive}
+              />
+            )}
+
+            {/* Text content */}
+            <div className={classes.textContent}>
+              <span
+                className={classnames([
+                  classes.name,
+                  isActive ? classes.activeName : null,
+                ])}
+              >
+                {name}
+              </span>
+              <span
+                className={classnames([
+                  classes.services,
+                  isActive ? classes.activeServices : null,
+                ])}
+              >
+                {services.length > 0
+                  ? services.join(', ')
+                  : intl.formatMessage(messages.noServicesAddedYet)}
+              </span>
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/src/features/workspaces/components/WorkspaceQuickSwitchBar.tsx
+++ b/src/features/workspaces/components/WorkspaceQuickSwitchBar.tsx
@@ -1,0 +1,166 @@
+import { mdiApps } from '@mdi/js';
+import classnames from 'classnames';
+import { observer } from 'mobx-react';
+import { Component, type ReactElement } from 'react';
+import {
+  type WrappedComponentProps,
+  defineMessages,
+  injectIntl,
+} from 'react-intl';
+import withStyles, { type WithStylesProps } from 'react-jss';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
+import Icon from '../../../components/ui/icon';
+import WorkspaceIcon from '../../../components/ui/WorkspaceIcon';
+import { altKey, cmdOrCtrlShortcutKey } from '../../../environment';
+import { acceleratorString } from '../../../jsUtils';
+import workspaceActions from '../actions';
+import { workspaceStore } from '../index';
+import type Workspace from '../models/Workspace';
+
+const messages = defineMessages({
+  allServices: {
+    id: 'workspaceDrawer.allServices',
+    defaultMessage: 'All services',
+  },
+});
+
+const styles = theme => ({
+  bar: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    width: '54px',
+    flexShrink: 0,
+    background: theme.workspaces.drawer.background,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    paddingTop: '8px',
+    paddingBottom: '8px',
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+    // Subtle right border to separate from service bar
+    borderRight: `1px solid ${theme.workspaces.drawer.listItem.border}`,
+  },
+  item: {
+    width: '38px',
+    height: '38px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    marginBottom: '6px',
+    cursor: 'pointer',
+    transition: 'background-color 150ms',
+    flexShrink: 0,
+    '&:hover': {
+      backgroundColor: theme.workspaces.drawer.listItem.hoverBackground,
+    },
+  },
+  activeItem: {
+    backgroundColor: theme.workspaces.drawer.listItem.activeBackground,
+    '&:hover': {
+      backgroundColor: theme.workspaces.drawer.listItem.activeBackground,
+    },
+  },
+  icon: {
+    fill: theme.workspaces.drawer.listItem.name.color,
+  },
+  activeIcon: {
+    fill: theme.workspaces.drawer.listItem.name.activeColor,
+  },
+});
+
+interface IProps extends WithStylesProps<typeof styles>, WrappedComponentProps {
+  workspaces: Workspace[];
+  activeWorkspace: Workspace | null | undefined;
+  hideAllServicesWorkspace?: boolean;
+}
+
+@observer
+class WorkspaceQuickSwitchBar extends Component<IProps> {
+  static defaultProps = {
+    hideAllServicesWorkspace: false,
+  };
+
+  render(): ReactElement {
+    const {
+      classes,
+      workspaces,
+      activeWorkspace,
+      hideAllServicesWorkspace,
+      intl,
+    } = this.props;
+
+    return (
+      <div className={classes.bar}>
+        {/* "All services" entry */}
+        {!hideAllServicesWorkspace && (
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+          <div
+            className={classnames([
+              classes.item,
+              !activeWorkspace ? classes.activeItem : null,
+            ])}
+            onClick={() => {
+              workspaceActions.deactivate();
+            }}
+            onKeyDown={() => {}}
+            data-tooltip-id="tooltip-quick-switch-bar"
+            data-tooltip-content={intl.formatMessage(messages.allServices)}
+          >
+            <Icon
+              icon={mdiApps}
+              size={1.1}
+              className={classnames([
+                classes.icon,
+                !activeWorkspace ? classes.activeIcon : null,
+              ])}
+            />
+          </div>
+        )}
+
+        {workspaces.map((workspace, index) => (
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+          <div
+            key={workspace.id}
+            className={classnames([
+              classes.item,
+              activeWorkspace === workspace ? classes.activeItem : null,
+            ])}
+            onClick={() => {
+              if (activeWorkspace !== workspace) {
+                workspaceActions.activate({ workspace });
+              }
+            }}
+            onKeyDown={() => {}}
+            data-tooltip-id="tooltip-quick-switch-bar"
+            data-tooltip-content={`${workspace.name} (${acceleratorString({
+              index: index + 1,
+              keyCombo: `${cmdOrCtrlShortcutKey(false)}+${altKey(false)}`,
+            })})`}
+          >
+            <WorkspaceIcon
+              iconPath={workspace.iconPath}
+              name={workspace.name}
+              size={32}
+              isActive={activeWorkspace === workspace}
+            />
+          </div>
+        ))}
+
+        <ReactTooltip
+          id="tooltip-quick-switch-bar"
+          place="right"
+          variant="dark"
+          style={{ height: 'auto', zIndex: 210 }}
+        />
+      </div>
+    );
+  }
+}
+
+export default injectIntl(
+  withStyles(styles, { injectTheme: true })(WorkspaceQuickSwitchBar),
+);

--- a/src/features/workspaces/models/Workspace.ts
+++ b/src/features/workspaces/models/Workspace.ts
@@ -13,6 +13,8 @@ export default class Workspace {
 
   @observable userId = null;
 
+  @observable iconPath: string | null = null;
+
   constructor(data) {
     if (!data.id) {
       throw new Error('Workspace requires Id');
@@ -23,6 +25,7 @@ export default class Workspace {
     this.id = data.id;
     this.name = data.name;
     this.order = data.order;
+    this.iconPath = data.iconPath || null;
 
     let { services } = data;
     if (data.saving && Boolean(data.keepLoaded)) {

--- a/src/features/workspaces/store.ts
+++ b/src/features/workspaces/store.ts
@@ -19,8 +19,8 @@ import { KEEP_WS_LOADED_USID } from '../../config';
 import type Workspace from './models/Workspace';
 
 const { app } = require('@electron/remote');
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 
 const debug = require('../../preload-safe-debug')(
   'Ferdium:feature:workspaces:store',
@@ -144,6 +144,7 @@ export default class WorkspacesStore extends FeatureStore {
       this._setActiveServiceOnWorkspaceSwitchReaction,
       this._activateLastUsedWorkspaceReaction,
       this._setWorkspaceBeingEditedReaction,
+      this._loadIconPathsReaction,
     ]);
     this._registerReactions(this._allReactions);
 
@@ -189,6 +190,23 @@ export default class WorkspacesStore extends FeatureStore {
     });
   };
 
+  // Returns the localStorage key for a workspace's icon path
+  _iconStorageKey = (workspaceId: string) => `workspace-icon:${workspaceId}`;
+
+  // Load all locally persisted icon paths into workspace models
+  _loadIconPaths = () => {
+    for (const workspace of this.workspaces) {
+      const stored = localStorage.getItem(this._iconStorageKey(workspace.id));
+      if (stored && fs.existsSync(stored)) {
+        workspace.iconPath = stored;
+      } else if (stored) {
+        // File was deleted externally — clean up the key
+        localStorage.removeItem(this._iconStorageKey(workspace.id));
+        workspace.iconPath = null;
+      }
+    }
+  };
+
   // Actions
 
   @action _edit = ({ workspace }) => {
@@ -202,16 +220,20 @@ export default class WorkspacesStore extends FeatureStore {
   };
 
   @action _delete = async ({ workspace }) => {
-    // Clean up icon file if it exists
+    // Clean up icon file and localStorage key if they exist
     if (workspace.iconPath) {
       try {
-        const fullIconPath = path.join(getWorkspaceIconsDir(), path.basename(workspace.iconPath));
+        const fullIconPath = path.join(
+          getWorkspaceIconsDir(),
+          path.basename(workspace.iconPath),
+        );
         if (fs.existsSync(fullIconPath)) {
           fs.unlinkSync(fullIconPath);
         }
-      } catch (e) {
-        debug('WorkspacesStore::_delete - failed to remove icon file', e);
+      } catch (error) {
+        debug('WorkspacesStore::_delete - failed to remove icon file', error);
       }
+      localStorage.removeItem(this._iconStorageKey(workspace.id));
     }
     await deleteWorkspaceRequest.execute(workspace).promise;
     await getUserWorkspacesRequest.result.remove(workspace);
@@ -235,7 +257,7 @@ export default class WorkspacesStore extends FeatureStore {
     const [moved] = workspaces.splice(oldIndex, 1);
     workspaces.splice(newIndex, 0, moved);
 
-    // Update order property on each workspace and persist
+    // Update order property on each workspace locally
     workspaces.forEach((ws, idx) => {
       const localWorkspace = this._getWorkspaceById(ws.id);
       if (localWorkspace) {
@@ -243,17 +265,21 @@ export default class WorkspacesStore extends FeatureStore {
       }
     });
 
-    // Persist each reordered workspace to the local server
-    for (const ws of workspaces) {
-      try {
-        await reorderWorkspaceRequest.execute({ id: ws.id, order: ws.order }).promise;
-      } catch (e) {
-        debug('WorkspacesStore::_reorderWorkspace - server reorder failed (non-fatal)', e);
-      }
-    }
+    // Persist reordered workspaces to the local server sequentially
+    const reorderPromises = workspaces.map(ws =>
+      reorderWorkspaceRequest
+        .execute({ id: ws.id, order: ws.order })
+        .promise.catch(error => {
+          debug(
+            'WorkspacesStore::_reorderWorkspace - server reorder failed (non-fatal)',
+            error,
+          );
+        }),
+    );
+    await Promise.all(reorderPromises);
   };
 
-  @action _saveWorkspaceIcon = async ({ workspaceId, iconPath: srcPath }) => {
+  @action _saveWorkspaceIcon = ({ workspaceId, iconPath: srcPath }) => {
     try {
       const iconsDir = getWorkspaceIconsDir();
       const ext = path.extname(srcPath) || '.png';
@@ -265,29 +291,35 @@ export default class WorkspacesStore extends FeatureStore {
       const localWorkspace = this._getWorkspaceById(workspaceId);
       if (localWorkspace) {
         localWorkspace.iconPath = destPath;
-        // Persist to server (iconPath stored in the data column via updateWorkspace)
-        await updateWorkspaceRequest.execute(localWorkspace).promise;
+        // Persist path to localStorage — survives reloads without server round-trip
+        localStorage.setItem(this._iconStorageKey(workspaceId), destPath);
       }
-    } catch (e) {
-      debug('WorkspacesStore::_saveWorkspaceIcon - failed', e);
+    } catch (error) {
+      debug('WorkspacesStore::_saveWorkspaceIcon - failed', error);
     }
   };
 
-  @action _deleteWorkspaceIcon = async ({ workspaceId }) => {
+  @action _deleteWorkspaceIcon = ({ workspaceId }) => {
     const localWorkspace = this._getWorkspaceById(workspaceId);
-    if (!localWorkspace || !localWorkspace.iconPath) return;
+    if (!localWorkspace?.iconPath) return;
 
     try {
-      const fullPath = path.join(getWorkspaceIconsDir(), path.basename(localWorkspace.iconPath));
+      const fullPath = path.join(
+        getWorkspaceIconsDir(),
+        path.basename(localWorkspace.iconPath),
+      );
       if (fs.existsSync(fullPath)) {
         fs.unlinkSync(fullPath);
       }
-    } catch (e) {
-      debug('WorkspacesStore::_deleteWorkspaceIcon - failed to remove file', e);
+    } catch (error) {
+      debug(
+        'WorkspacesStore::_deleteWorkspaceIcon - failed to remove file',
+        error,
+      );
     }
 
     localWorkspace.iconPath = null;
-    await updateWorkspaceRequest.execute(localWorkspace).promise;
+    localStorage.removeItem(this._iconStorageKey(workspaceId));
   };
 
   @action _setNextWorkspace(workspace) {
@@ -418,6 +450,12 @@ export default class WorkspacesStore extends FeatureStore {
   };
 
   // Reactions
+
+  _loadIconPathsReaction = () => {
+    if (this.workspaces.length > 0) {
+      this._loadIconPaths();
+    }
+  };
 
   _setWorkspaceBeingEditedReaction = () => {
     const { pathname } = this.stores.router.location;

--- a/src/features/workspaces/store.ts
+++ b/src/features/workspaces/store.ts
@@ -9,6 +9,7 @@ import {
   createWorkspaceRequest,
   deleteWorkspaceRequest,
   getUserWorkspacesRequest,
+  reorderWorkspaceRequest,
   updateWorkspaceRequest,
 } from './api';
 import { WORKSPACES_ROUTES } from './constants';
@@ -16,6 +17,10 @@ import { WORKSPACES_ROUTES } from './constants';
 import type { Actions } from '../../actions/lib/actions';
 import { KEEP_WS_LOADED_USID } from '../../config';
 import type Workspace from './models/Workspace';
+
+const { app } = require('@electron/remote');
+const path = require('path');
+const fs = require('fs');
 
 const debug = require('../../preload-safe-debug')(
   'Ferdium:feature:workspaces:store',
@@ -34,6 +39,16 @@ const getDrawerAnimationDuration = () => {
     '(prefers-reduced-motion: reduce)',
   ).matches;
   return prefersReducedMotion ? 0 : 500;
+};
+
+// Returns the directory where workspace icons are stored
+const getWorkspaceIconsDir = (): string => {
+  const userDataPath = app.getPath('userData');
+  const iconsDir = path.join(userDataPath, 'workspaceIcons');
+  if (!fs.existsSync(iconsDir)) {
+    fs.mkdirSync(iconsDir, { recursive: true });
+  }
+  return iconsDir;
 };
 
 export default class WorkspacesStore extends FeatureStore {
@@ -63,7 +78,9 @@ export default class WorkspacesStore extends FeatureStore {
 
   @computed get workspaces() {
     if (!this.isFeatureActive) return [];
-    return getUserWorkspacesRequest.result || [];
+    const ws = getUserWorkspacesRequest.result || [];
+    // Sort by order field so reordering is reflected everywhere
+    return [...ws].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   }
 
   @computed get settings() {
@@ -113,6 +130,9 @@ export default class WorkspacesStore extends FeatureStore {
         workspaceActions.toggleKeepAllWorkspacesLoadedSetting,
         this._toggleKeepAllWorkspacesLoadedSetting,
       ],
+      [workspaceActions.reorder, this._reorderWorkspace],
+      [workspaceActions.saveIcon, this._saveWorkspaceIcon],
+      [workspaceActions.deleteIcon, this._deleteWorkspaceIcon],
     ]);
     this._registerActions(this._allActions);
 
@@ -182,6 +202,17 @@ export default class WorkspacesStore extends FeatureStore {
   };
 
   @action _delete = async ({ workspace }) => {
+    // Clean up icon file if it exists
+    if (workspace.iconPath) {
+      try {
+        const fullIconPath = path.join(getWorkspaceIconsDir(), path.basename(workspace.iconPath));
+        if (fs.existsSync(fullIconPath)) {
+          fs.unlinkSync(fullIconPath);
+        }
+      } catch (e) {
+        debug('WorkspacesStore::_delete - failed to remove icon file', e);
+      }
+    }
     await deleteWorkspaceRequest.execute(workspace).promise;
     await getUserWorkspacesRequest.result.remove(workspace);
     this.stores.router.push('/settings/workspaces');
@@ -192,10 +223,71 @@ export default class WorkspacesStore extends FeatureStore {
 
   @action _update = async ({ workspace }) => {
     await updateWorkspaceRequest.execute(workspace).promise;
-    // Path local result optimistically
+    // Patch local result optimistically
     const localWorkspace = this._getWorkspaceById(workspace.id);
     Object.assign(localWorkspace, workspace);
     this.stores.router.push('/settings/workspaces');
+  };
+
+  @action _reorderWorkspace = async ({ oldIndex, newIndex }) => {
+    const workspaces = [...this.workspaces];
+    // Move item from old to new position
+    const [moved] = workspaces.splice(oldIndex, 1);
+    workspaces.splice(newIndex, 0, moved);
+
+    // Update order property on each workspace and persist
+    workspaces.forEach((ws, idx) => {
+      const localWorkspace = this._getWorkspaceById(ws.id);
+      if (localWorkspace) {
+        localWorkspace.order = idx;
+      }
+    });
+
+    // Persist each reordered workspace to the local server
+    for (const ws of workspaces) {
+      try {
+        await reorderWorkspaceRequest.execute({ id: ws.id, order: ws.order }).promise;
+      } catch (e) {
+        debug('WorkspacesStore::_reorderWorkspace - server reorder failed (non-fatal)', e);
+      }
+    }
+  };
+
+  @action _saveWorkspaceIcon = async ({ workspaceId, iconPath: srcPath }) => {
+    try {
+      const iconsDir = getWorkspaceIconsDir();
+      const ext = path.extname(srcPath) || '.png';
+      const destFilename = `${workspaceId}${ext}`;
+      const destPath = path.join(iconsDir, destFilename);
+
+      fs.copyFileSync(srcPath, destPath);
+
+      const localWorkspace = this._getWorkspaceById(workspaceId);
+      if (localWorkspace) {
+        localWorkspace.iconPath = destPath;
+        // Persist to server (iconPath stored in the data column via updateWorkspace)
+        await updateWorkspaceRequest.execute(localWorkspace).promise;
+      }
+    } catch (e) {
+      debug('WorkspacesStore::_saveWorkspaceIcon - failed', e);
+    }
+  };
+
+  @action _deleteWorkspaceIcon = async ({ workspaceId }) => {
+    const localWorkspace = this._getWorkspaceById(workspaceId);
+    if (!localWorkspace || !localWorkspace.iconPath) return;
+
+    try {
+      const fullPath = path.join(getWorkspaceIconsDir(), path.basename(localWorkspace.iconPath));
+      if (fs.existsSync(fullPath)) {
+        fs.unlinkSync(fullPath);
+      }
+    } catch (e) {
+      debug('WorkspacesStore::_deleteWorkspaceIcon - failed to remove file', e);
+    }
+
+    localWorkspace.iconPath = null;
+    await updateWorkspaceRequest.execute(localWorkspace).promise;
   };
 
   @action _setNextWorkspace(workspace) {

--- a/src/internal-server/app/Controllers/Http/WorkspaceController.js
+++ b/src/internal-server/app/Controllers/Http/WorkspaceController.js
@@ -69,13 +69,40 @@ class WorkspaceController {
     const data = request.all();
     const { id } = params;
 
+    // Build update object — include order and iconPath if provided
+    const updateData = {
+      name: data.name,
+      services: JSON.stringify(data.services),
+    };
+
+    if (data.order !== undefined) {
+      updateData.order = data.order;
+    }
+
+    // iconPath is stored in the extra data column as JSON
+    // We read existing data first so we don't wipe other fields
+    const existingQuery = await Workspace.query()
+      .where('workspaceId', id)
+      .fetch();
+    const existing = existingQuery.rows[0];
+    let extraData = {};
+    if (existing && existing.data) {
+      try {
+        extraData = JSON.parse(existing.data);
+      } catch {
+        extraData = {};
+      }
+    }
+
+    if (data.iconPath !== undefined) {
+      extraData.iconPath = data.iconPath;
+    }
+    updateData.data = JSON.stringify(extraData);
+
     // Update data in database
     await Workspace.query()
       .where('workspaceId', id)
-      .update({
-        name: data.name,
-        services: JSON.stringify(data.services),
-      });
+      .update(updateData);
 
     // Get updated row
     const workspaceQuery = await Workspace.query()
@@ -83,11 +110,20 @@ class WorkspaceController {
       .fetch();
     const workspace = workspaceQuery.rows[0];
 
+    let iconPath = null;
+    try {
+      const parsedData = JSON.parse(workspace.data || '{}');
+      iconPath = parsedData.iconPath || null;
+    } catch {
+      iconPath = null;
+    }
+
     return response.send({
       id: workspace.workspaceId,
       name: data.name,
       order: workspace.order,
       services: data.services,
+      iconPath,
       userId: 1,
     });
   }
@@ -115,6 +151,25 @@ class WorkspaceController {
     });
   }
 
+  // Reorder a single workspace
+  async reorder({ request, response, params }) {
+    const { id } = params;
+    const data = request.all();
+
+    if (data.order === undefined) {
+      return response.status(400).send({
+        message: 'order is required',
+        status: 400,
+      });
+    }
+
+    await Workspace.query()
+      .where('workspaceId', id)
+      .update({ order: data.order });
+
+    return response.send({ id, order: data.order });
+  }
+
   // List all workspaces a user has created
   async list({ response }) {
     const allWorkspaces = await Workspace.all();
@@ -122,13 +177,27 @@ class WorkspaceController {
     // Convert to array with all data Franz wants
     let workspacesArray = [];
     if (workspaces) {
-      workspacesArray = workspaces.map(workspace => ({
-        id: workspace.workspaceId,
-        name: workspace.name,
-        order: workspace.order,
-        services: convertToJSON(workspace.services),
-        userId: 1,
-      }));
+      workspacesArray = workspaces.map(workspace => {
+        let iconPath = null;
+        try {
+          const extraData = JSON.parse(workspace.data || '{}');
+          iconPath = extraData.iconPath || null;
+        } catch {
+          iconPath = null;
+        }
+
+        return {
+          id: workspace.workspaceId,
+          name: workspace.name,
+          order: workspace.order,
+          services: convertToJSON(workspace.services),
+          iconPath,
+          userId: 1,
+        };
+      });
+
+      // Sort by order ascending
+      workspacesArray.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     }
 
     return response.send(workspacesArray);

--- a/src/internal-server/start/routes.js
+++ b/src/internal-server/start/routes.js
@@ -87,6 +87,7 @@ Route.group(() => {
   Route.post('recipes/update', 'RecipeController.update');
 
   // Workspaces
+  Route.put('workspace/reorder/:id', 'WorkspaceController.reorder');
   Route.put('workspace/:id', 'WorkspaceController.edit');
   Route.delete('workspace/:id', 'WorkspaceController.delete');
   Route.post('workspace', 'WorkspaceController.create');


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Adds three quality-of-life improvements to the workspace system:

- **Workspace profile pictures** — pick any image per workspace, stored locally in `userData/workspaceIcons/`. Falls back to first-letter initials. No server sync required, works in accountless mode.
- **Drag-to-reorder workspaces** — native HTML5 drag and drop in the drawer, order persisted to the local server.
- **Quick-switch sidebar** — slim icon bar sits next to the service sidebar when the drawer is closed. One click to switch workspaces without opening the drawer.

#### Motivation and Context

Previous attempts at workspace icons (#1240) and reorder (#497) both stalled on server sync complexity. This implementation removes that blocker entirely — icons are local files, order uses the existing `order` column already in the schema. 13 files changed, no new dependencies, no schema migrations required.

#### Screenshots

A working Windows build is available to test at:
https://github.com/Rhino47/ferdium-app/releases/tag/v7.1.3-rhino.1

#### Checklist

- [x] My pull request is properly named
- [x] I tested/previewed my changes locally

#### Release Notes

feat: add workspace profile pictures, drag-to-reorder, and quick-switch sidebar — built by [@Rhino47](https://github.com/Rhino47) / Mister Rhino