### PR TITLE
feat: update user agent with dynamic Ferdium version

### DIFF
--- a/src/helpers/userAgent-helpers.ts
+++ b/src/helpers/userAgent-helpers.ts
@@ -2,12 +2,15 @@ import { cpus } from 'node:os';
 import macosVersion from 'macos-version';
 import {
   chromeVersion,
+  electronVersion,
   is64Bit,
   isMac,
   isWindows,
   osArch,
   osRelease,
 } from '../environment';
+// @ts-expect-error Cannot find module '../package.json' or its corresponding type declarations.
+import { version as ferdiumVersion } from '../package.json';
 
 const macOS = () => {
   const version = macosVersion() ?? '';
@@ -42,5 +45,5 @@ export default function userAgent() {
     platformString = linux();
   }
 
-  return `Mozilla/5.0 (${platformString}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
+  return `Mozilla/5.0 (${platformString}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36 Ferdium/${ferdiumVersion} (Electron ${electronVersion})`;
 }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Updates the Ferdium user agent to dynamically include version information. The Ferdium version is now automatically retrieved from `package.json` instead of being hardcoded, and the Electron version is included in the user agent string.

This fixes the Google Calendar constant refresh issue caused by an outdated user agent string.

#### Motivation and Context
The user agent was previously missing the Ferdium and Electron version signatures and was outdated, causing service compatibility issues. This was particularly affecting Google Calendar which was constantly refreshing instead of showing the authentication page.

Fixes #2439

#### Checklist
- [x] My pull request is properly named
- [x] The changes respect the code style of the project
- [x] I tested my changes locally

#### Release Notes
User agent now includes Ferdium version and automatically updates with each release. Fixes constant page refresh on Google Calendar and other services with strict user agent validation.
