### PR TITLE
fix: service is permanently stuck on loading screen

### DIFF
--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -414,9 +414,35 @@ export default class Service {
   }
 
   initializeWebViewEvents({ handleIPCMessage, openWindow, stores }): void {
-    const webviewWebContents = webContents.fromId(
-      this.webview.getWebContentsId(),
-    );
+    let webviewWebContents;
+    try {
+      webviewWebContents = webContents.fromId(this.webview.getWebContentsId());
+    } catch (error) {
+      // The <webview> can still be mid-attach here even after the
+      // setTimeout(0) workaround in ServiceWebview's onDidAttach (see
+      // https://github.com/electron/electron/issues/31918). getWebContentsId
+      // throws in that case instead of returning a usable id. Rather than
+      // assuming a fixed delay is enough (and silently never initializing
+      // the service, leaving it stuck in its default "loading" state
+      // forever), retry once the webview itself reports it's actually
+      // ready.
+      debug(
+        'Webview was not ready yet, retrying once dom-ready fires',
+        this.name,
+        error,
+      );
+      this.webview.addEventListener(
+        'dom-ready',
+        () =>
+          this.initializeWebViewEvents({
+            handleIPCMessage,
+            openWindow,
+            stores,
+          }),
+        { once: true },
+      );
+      return;
+    }
 
     this.userAgentModel.setWebviewReference(this.webview);
 

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -414,9 +414,18 @@ export default class Service {
   }
 
   initializeWebViewEvents({ handleIPCMessage, openWindow, stores }): void {
+    const { webview } = this;
+    if (!webview) {
+      debug(
+        'Webview is no longer available; skipping event initialization',
+        this.name,
+      );
+      return;
+    }
+
     let webviewWebContents;
     try {
-      webviewWebContents = webContents.fromId(this.webview.getWebContentsId());
+      webviewWebContents = webContents.fromId(webview.getWebContentsId());
     } catch (error) {
       // The <webview> can still be mid-attach here even after the
       // setTimeout(0) workaround in ServiceWebview's onDidAttach (see
@@ -431,21 +440,27 @@ export default class Service {
         this.name,
         error,
       );
-      this.webview.addEventListener(
+      webview.addEventListener(
         'dom-ready',
-        () =>
+        () => {
+          // The service may have been detached or assigned a replacement
+          // webview while this one was finishing its attach lifecycle.
+          if (this.webview !== webview) {
+            debug('Ignoring dom-ready from a stale webview', this.name);
+            return;
+          }
+
           this.initializeWebViewEvents({
             handleIPCMessage,
             openWindow,
             stores,
-          }),
+          });
+        },
         { once: true },
       );
       return;
     }
-
-    this.userAgentModel.setWebviewReference(this.webview);
-
+    this.userAgentModel.setWebviewReference(webview);
     // If the recipe has implemented 'modifyRequestHeaders',
     // Send those headers to ipcMain so that it can be set in session
     if (typeof this.recipe.modifyRequestHeaders === 'function') {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
Fix for the loading screen that is sometimes stuck.

This happens because `getWebContentsId()` throws an Error if the <webview> isn't fully attached yet (a known Electron timing issue, electron/electron#31918), and when it throws the Error, the function bails out before registering a single webview event listener. So nothing is ever left in the app that could clear the loading state for that service.

#### Motivation and Context
Me, along with many others, experience this bug and when it happens, the only solution is to reload the service (helps sometimes) or restart Ferdium as a whole (helps often). For me personally, with 9 services, this happens 90% of the time to at least 1 service when I start Ferdium in the morning.

This was also how I was able to verify that this fixes the bug 100% of the time. I started a patched Ferdium 10 times in a row which is 90 services, and none of them failed. The original Ferdium has at least 1 or 2 services stuck on every boot.

This issue is described in #1608, and an attempt to completely remove the loading screen was done in #2334 however @SpecialAro wanted to keep the Loading overlay as-is and instead asked to fix the root cause of this issue so that's why I dove into the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

Fix for the loading screen that is sometimes stuck