### PR TITLE
fix: fill injected <style> elements via textContent, not innerHTML

### DIFF
--- a/src/webview/contextMenuBuilder.ts
+++ b/src/webview/contextMenuBuilder.ts
@@ -99,7 +99,10 @@ const translatePopup = (res, isError: boolean = false) => {
   }
 
   const style = document.createElement('style');
-  style.innerHTML = `
+  // textContent, not innerHTML: innerHTML is a Trusted Types sink, so sites
+  // sending `require-trusted-types-for 'script'` reject the assignment and the
+  // translator popup renders unstyled.
+  style.textContent = `
     .container-ferdium-translator {
       position: fixed;
       opacity: 0.9;

--- a/src/webview/darkmode.ts
+++ b/src/webview/darkmode.ts
@@ -23,7 +23,10 @@ export const injectDarkModeStyle = (recipePath: string) => {
     const data = readFileSync(darkmodeCss);
     const styles = document.createElement('style');
     styles.id = ID;
-    styles.innerHTML = data.toString();
+    // textContent, not innerHTML: innerHTML is a Trusted Types sink, so sites
+    // sending `require-trusted-types-for 'script'` reject the assignment and
+    // darkmode.css is never applied.
+    styles.textContent = data.toString();
     debug('Loaded darkmode.css from: ', darkmodeCss);
 
     document.querySelector('head')?.append(styles);

--- a/src/webview/lib/RecipeWebview.ts
+++ b/src/webview/lib/RecipeWebview.ts
@@ -131,7 +131,10 @@ class RecipeWebview {
     files.forEach(file => {
       if (pathExistsSync(file)) {
         const styles = document.createElement('style');
-        styles.innerHTML = readFileSync(file, 'utf8');
+        // textContent, not innerHTML: innerHTML is a Trusted Types sink, so
+        // sites sending `require-trusted-types-for 'script'` reject the
+        // assignment and the stylesheet is never applied.
+        styles.textContent = readFileSync(file, 'utf8');
 
         const head = document.querySelector('head');
 

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -267,7 +267,11 @@ class RecipeController {
     const userCss = join(recipe.path, 'user.css');
     if (pathExistsSync(userCss)) {
       const data = readFileSync(userCss);
-      styles.innerHTML += data.toString();
+      // textContent, not innerHTML: innerHTML is a Trusted Types sink, so
+      // sites sending `require-trusted-types-for 'script'` reject the
+      // assignment. That threw here before reaching the user.js block below,
+      // so a single user.css took user.js down with it (ferdium#1086).
+      styles.textContent += data.toString();
       debug('Loaded user.css from: ', userCss);
     }
     document.querySelector('head')?.append(styles);


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Every place we fill an injected `<style>` element used `innerHTML`, which is a [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) injection sink. On a service whose document sends `require-trusted-types-for 'script'`, that assignment throws and the stylesheet is **silently never applied**.

`textContent` is not a sink, and for a `<style>` element it is an equivalent way to set the stylesheet text — so this is a drop-in swap, four call sites:

| file | what silently fails today |
|---|---|
| `src/webview/darkmode.ts` | `darkmode.css` never applied |
| `src/webview/lib/RecipeWebview.ts` | recipe `Ferdium.injectCSS()` never applied |
| `src/webview/recipe.ts` | `user.css` never applied |
| `src/webview/contextMenuBuilder.ts` | translator popup renders unstyled |

The `recipe.ts` one is the worst of the four. The throw escapes `loadUserFiles()` before it reaches the `user.js` block further down the same function, so **a single `user.css` file takes `user.js` down with it** — which is precisely the traceback in #1086.

`src/features/appearance/index.ts` also fills a `<style>` via `innerHTML`, but I deliberately left it alone: it styles Ferdium's own renderer document, which no third-party CSP applies to.

#### Motivation and Context

#1086 reported `user.js` failing to load on Google Calendar with:

```
TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.
    at v.loadUserFiles (recipe.js:1:4621)
```

It was closed as fixed by ferdium/ferdium-recipes#402, but that PR only routed *one recipe's own* stylesheet around the problem by hosting it on a CDN — `recipe.ts:270` was never touched, so `user.css`/`user.js` are still broken on any such service. This addresses the actual sink.

This is not hypothetical or spec-lawyering — I verified it in Electron 37 (the version this repo pins) against a page carrying that exact CSP:

```json
{
  "innerHTML":            "TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.",
  "textContent":          "OK",
  "textContentPlusEquals": "OK",
  "appliedFontWeight":    "700",   // textContent stylesheet took effect
  "appliedColor":         "rgb(0, 0, 0)",  // innerHTML stylesheet did NOT (would be rgb(1,2,3))
  "appliedLetterSpacing": "3px"    // the `+=` form used in recipe.ts also works
}
```

Note the error string is byte-identical to the one in #1086, and `appliedColor` confirms the failure mode is a silently-lost stylesheet rather than a visible crash.

Scope note, since I'd rather under-claim: I only have hard evidence for services that actually send this CSP. `messages.google.com` sends `require-trusted-types-for 'script'` as a response header today (which matches open #2295), and Google Calendar demonstrably enforces it per #1086's traceback. There are several other open "css not injecting" reports (#1607, #1102, #1060, #956, #2288) that *may* share this cause, but I could not confirm the CSP on those origins, so I'm not claiming this fixes them.

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes (6 suites, 81 passed, 2 skipped)
- [x] I tested/previewed my changes locally

One caveat worth flagging for reviewers: these four files are at 0% test coverage, so there is no automated test proving the behaviour change — hence the Electron probe above. Happy to add a regression test if you want one, though it would need a DOM test environment (the suite currently runs `testEnvironment: 'node'`).

Behavioural difference to be aware of: `innerHTML` decodes HTML entities while `textContent` does not, so a stylesheet literally containing something like `&gt;` would now be taken verbatim. That is the correct reading for CSS, and no bundled stylesheet relies on it.

#### Release Notes

Fixed `user.css`, `darkmode.css` and recipe stylesheets not being applied on services that enforce Trusted Types (such as Google Calendar and Google Messages), which also prevented `user.js` from loading.
