### PR TITLE
Fix orphaned service partitions after service deletion

### DIFF
--- a/src/helpers/service-helpers.ts
+++ b/src/helpers/service-helpers.ts
@@ -37,7 +37,12 @@ const readPendingPartitionRemovals = (): string[] => {
     }
 
     return pendingRemovals.filter(
-      partition => typeof partition === 'string' && partition.length > 0,
+      partition =>
+        typeof partition === 'string' &&
+        partition.length > 0 &&
+        !partition.includes('..') &&
+        !partition.includes('/') &&
+        !partition.includes('\\'),
     );
   } catch (error) {
     debug('Unable to read pending service partition removals', error);
@@ -50,7 +55,9 @@ const writePendingPartitionRemovals = (pendingRemovals: string[]): void => {
 
   try {
     if (pendingRemovals.length === 0) {
-      removeSync(pendingRemovalsFile);
+      if (pathExistsSync(pendingRemovalsFile)) {
+        removeSync(pendingRemovalsFile);
+      }
       return;
     }
 
@@ -79,13 +86,23 @@ export const cleanupPendingServicePartitionDirectories = (): void => {
       removeSync(servicePartition);
       debug(`Removed deferred service partition "${servicePartition}"`);
     } catch (error) {
-      if ((error as FileSystemError).code !== 'ENOENT') {
-        remainingRemovals.push(partition);
-        debug(
-          `Unable to remove deferred service partition "${servicePartition}"`,
-          error,
-        );
+      const errorCode = (error as FileSystemError).code;
+
+      if (errorCode === 'ENOENT') {
+        continue;
       }
+
+      if (
+        errorCode !== undefined &&
+        RETRYABLE_PARTITION_REMOVAL_ERROR_CODES.has(errorCode)
+      ) {
+        remainingRemovals.push(partition);
+      }
+
+      debug(
+        `Unable to remove deferred service partition "${servicePartition}"`,
+        error,
+      );
     }
   }
 

--- a/src/helpers/service-helpers.ts
+++ b/src/helpers/service-helpers.ts
@@ -88,21 +88,19 @@ export const cleanupPendingServicePartitionDirectories = (): void => {
     } catch (error) {
       const errorCode = (error as FileSystemError).code;
 
-      if (errorCode === 'ENOENT') {
-        continue;
-      }
+      if (errorCode !== 'ENOENT') {
+        if (
+          errorCode !== undefined &&
+          RETRYABLE_PARTITION_REMOVAL_ERROR_CODES.has(errorCode)
+        ) {
+          remainingRemovals.push(partition);
+        }
 
-      if (
-        errorCode !== undefined &&
-        RETRYABLE_PARTITION_REMOVAL_ERROR_CODES.has(errorCode)
-      ) {
-        remainingRemovals.push(partition);
+        debug(
+          `Unable to remove deferred service partition "${servicePartition}"`,
+          error,
+        );
       }
-
-      debug(
-        `Unable to remove deferred service partition "${servicePartition}"`,
-        error,
-      );
     }
   }
 

--- a/src/helpers/service-helpers.ts
+++ b/src/helpers/service-helpers.ts
@@ -1,21 +1,136 @@
-import { readdirSync, removeSync } from 'fs-extra';
+import {
+  pathExistsSync,
+  readJsonSync,
+  readdirSync,
+  removeSync,
+  writeJsonSync,
+} from 'fs-extra';
 import { userDataPath } from '../environment-remote';
+
+const RETRYABLE_PARTITION_REMOVAL_ERROR_CODES = new Set([
+  'EACCES',
+  'EBUSY',
+  'ENOTEMPTY',
+  'EPERM',
+]);
+const debug = require('../preload-safe-debug')('Ferdium:ServiceHelpers');
+
+type FileSystemError = Error & { code?: string };
 
 export const getServicePartitionsDirectory = (...segments) => {
   return userDataPath('Partitions', ...[segments].flat());
+};
+
+const getPendingPartitionRemovalsFile = () =>
+  userDataPath('pending-service-partition-removals.json');
+
+const readPendingPartitionRemovals = (): string[] => {
+  const pendingRemovalsFile = getPendingPartitionRemovalsFile();
+  if (!pathExistsSync(pendingRemovalsFile)) {
+    return [];
+  }
+
+  try {
+    const pendingRemovals = readJsonSync(pendingRemovalsFile);
+    if (!Array.isArray(pendingRemovals)) {
+      return [];
+    }
+
+    return pendingRemovals.filter(
+      partition => typeof partition === 'string' && partition.length > 0,
+    );
+  } catch (error) {
+    debug('Unable to read pending service partition removals', error);
+    return [];
+  }
+};
+
+const writePendingPartitionRemovals = (pendingRemovals: string[]): void => {
+  const pendingRemovalsFile = getPendingPartitionRemovalsFile();
+
+  try {
+    if (pendingRemovals.length === 0) {
+      removeSync(pendingRemovalsFile);
+      return;
+    }
+
+    writeJsonSync(pendingRemovalsFile, [...new Set(pendingRemovals)]);
+  } catch (error) {
+    debug('Unable to persist pending service partition removals', error);
+  }
+};
+
+const deferPartitionRemoval = (partition: string): void => {
+  writePendingPartitionRemovals([...readPendingPartitionRemovals(), partition]);
+};
+
+export const cleanupPendingServicePartitionDirectories = (): void => {
+  const pendingRemovals = readPendingPartitionRemovals();
+  if (pendingRemovals.length === 0) {
+    return;
+  }
+
+  const remainingRemovals: string[] = [];
+
+  for (const partition of pendingRemovals) {
+    const servicePartition = getServicePartitionsDirectory(partition);
+
+    try {
+      removeSync(servicePartition);
+      debug(`Removed deferred service partition "${servicePartition}"`);
+    } catch (error) {
+      if ((error as FileSystemError).code !== 'ENOENT') {
+        remainingRemovals.push(partition);
+        debug(
+          `Unable to remove deferred service partition "${servicePartition}"`,
+          error,
+        );
+      }
+    }
+  }
+
+  writePendingPartitionRemovals(remainingRemovals);
 };
 
 export const removeServicePartitionDirectory = (
   id = '',
   addServicePrefix = false,
 ): void => {
-  const servicePartition = getServicePartitionsDirectory(
-    `${addServicePrefix ? 'service-' : ''}${id}`,
-  );
-  removeSync(servicePartition);
+  const partition = `${addServicePrefix ? 'service-' : ''}${id}`;
+  const servicePartition = getServicePartitionsDirectory(partition);
+
+  try {
+    removeSync(servicePartition);
+  } catch (error) {
+    const errorCode = (error as FileSystemError).code;
+
+    if (errorCode === 'ENOENT') {
+      return;
+    }
+
+    if (
+      errorCode !== undefined &&
+      RETRYABLE_PARTITION_REMOVAL_ERROR_CODES.has(errorCode)
+    ) {
+      deferPartitionRemoval(partition);
+      debug(
+        `Service partition "${servicePartition}" is still in use; deferring removal until next app start`,
+        error,
+      );
+      return;
+    }
+
+    debug(`Unable to remove service partition "${servicePartition}"`, error);
+  }
 };
 
 export async function getServiceIdsFromPartitions(): Promise<string[]> {
   const files = readdirSync(getServicePartitionsDirectory());
   return files.filter(n => n !== '__chrome_extension');
 }
+
+// Persistent Electron sessions can keep files open for the lifetime of the app.
+// ServerApi imports this helper before service webviews are created, so this is
+// the earliest safe point in the renderer startup to remove partitions that
+// were locked when their service was deleted during the previous run.
+cleanupPendingServicePartitionDirectories();

--- a/test/helpers/service-helpers.test.ts
+++ b/test/helpers/service-helpers.test.ts
@@ -1,0 +1,132 @@
+jest.mock('fs-extra', () => ({
+  pathExistsSync: jest.fn(),
+  readJsonSync: jest.fn(),
+  readdirSync: jest.fn(),
+  removeSync: jest.fn(),
+  writeJsonSync: jest.fn(),
+}));
+
+jest.mock('../../src/environment-remote', () => ({
+  userDataPath: jest.fn((...segments: string[]) => segments.join('/')),
+}));
+
+const mockPreloadSafeDebug = () => jest.fn();
+
+jest.mock('../../src/preload-safe-debug', () => mockPreloadSafeDebug);
+
+const fsExtra = jest.requireMock('fs-extra') as typeof import('fs-extra');
+const {
+  cleanupPendingServicePartitionDirectories,
+  getServicePartitionsDirectory,
+  removeServicePartitionDirectory,
+} = jest.requireActual(
+  '../../src/helpers/service-helpers',
+) as typeof import('../../src/helpers/service-helpers');
+
+const mockedPathExistsSync = jest.mocked(fsExtra.pathExistsSync);
+const mockedReadJsonSync = jest.mocked(fsExtra.readJsonSync);
+const mockedRemoveSync = jest.mocked(fsExtra.removeSync);
+const mockedWriteJsonSync = jest.mocked(fsExtra.writeJsonSync);
+
+const pendingRemovalsFile = 'pending-service-partition-removals.json';
+
+describe('service_helpers', () => {
+  beforeEach(() => {
+    mockedPathExistsSync.mockReset();
+    mockedReadJsonSync.mockReset();
+    mockedRemoveSync.mockReset();
+    mockedWriteJsonSync.mockReset();
+    mockedPathExistsSync.mockReturnValue(false);
+  });
+
+  it('builds paths inside the Partitions directory', () => {
+    expect(getServicePartitionsDirectory('service-id', 'Cache')).toBe(
+      'Partitions/service-id/Cache',
+    );
+  });
+
+  it('removes a service partition immediately when it is not locked', () => {
+    removeServicePartitionDirectory('abc123', true);
+
+    expect(mockedRemoveSync).toHaveBeenCalledWith('Partitions/service-abc123');
+    expect(mockedWriteJsonSync).not.toHaveBeenCalled();
+  });
+
+  it('defers removal when Chromium still has files in use', () => {
+    const lockedError = Object.assign(new Error('Partition is locked'), {
+      code: 'EBUSY',
+    });
+    mockedRemoveSync.mockImplementationOnce(() => {
+      throw lockedError;
+    });
+
+    removeServicePartitionDirectory('abc123', true);
+
+    expect(mockedRemoveSync).toHaveBeenCalledWith('Partitions/service-abc123');
+    expect(mockedWriteJsonSync).toHaveBeenCalledWith(pendingRemovalsFile, [
+      'service-abc123',
+    ]);
+  });
+
+  it('preserves existing deferred removals when another partition is locked', () => {
+    const lockedError = Object.assign(new Error('Partition is locked'), {
+      code: 'EPERM',
+    });
+    mockedPathExistsSync.mockReturnValue(true);
+    mockedReadJsonSync.mockReturnValue(['service-existing']);
+    mockedRemoveSync.mockImplementationOnce(() => {
+      throw lockedError;
+    });
+
+    removeServicePartitionDirectory('abc123', true);
+
+    expect(mockedWriteJsonSync).toHaveBeenCalledWith(pendingRemovalsFile, [
+      'service-existing',
+      'service-abc123',
+    ]);
+  });
+
+  it('does not defer errors unrelated to file locks', () => {
+    const invalidPathError = Object.assign(new Error('Invalid path'), {
+      code: 'EINVAL',
+    });
+    mockedRemoveSync.mockImplementationOnce(() => {
+      throw invalidPathError;
+    });
+
+    removeServicePartitionDirectory('abc123', true);
+
+    expect(mockedWriteJsonSync).not.toHaveBeenCalled();
+  });
+
+  it('removes deferred partitions on the next startup', () => {
+    mockedPathExistsSync.mockReturnValue(true);
+    mockedReadJsonSync.mockReturnValue(['service-abc123']);
+
+    cleanupPendingServicePartitionDirectories();
+
+    expect(mockedRemoveSync).toHaveBeenNthCalledWith(
+      1,
+      'Partitions/service-abc123',
+    );
+    expect(mockedRemoveSync).toHaveBeenNthCalledWith(2, pendingRemovalsFile);
+    expect(mockedWriteJsonSync).not.toHaveBeenCalled();
+  });
+
+  it('keeps a deferred partition queued if startup cleanup still cannot remove it', () => {
+    const lockedError = Object.assign(new Error('Partition is still locked'), {
+      code: 'EBUSY',
+    });
+    mockedPathExistsSync.mockReturnValue(true);
+    mockedReadJsonSync.mockReturnValue(['service-abc123']);
+    mockedRemoveSync.mockImplementationOnce(() => {
+      throw lockedError;
+    });
+
+    cleanupPendingServicePartitionDirectories();
+
+    expect(mockedWriteJsonSync).toHaveBeenCalledWith(pendingRemovalsFile, [
+      'service-abc123',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

This change fixes service partition directories being left behind after a service is deleted.

Ferdium now attempts to remove the corresponding `service-<uuid>` partition immediately. If Chromium still has files in the partition open and Windows returns a lock-related filesystem error such as `EBUSY`, `EPERM`, `EACCES`, or `ENOTEMPTY`, the partition is queued for deferred cleanup.

Deferred partitions are removed on the next Ferdium startup, after the previous Electron process has released its file handles.

This also adds tests covering immediate cleanup, deferred cleanup, and error handling.

#### Motivation and Context

Fixes #646.

Previously, deleting a service could leave its partition directory permanently under the Ferdium `Partitions` directory.

On Windows, Chromium may continue holding files such as `DIPS` open even after the service has been removed. Because persistent Electron sessions can remain alive for the lifetime of the application process, attempting to delete the directory immediately can fail with `EBUSY`.

Deferring the cleanup until the next application startup allows Ferdium to remove these partitions once Chromium has released the files, while still removing partitions immediately when no lock is present.

#### Screenshots

Not applicable.

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

Fix leftover service data partitions after deleting a service.