### PR TITLE
Fix webview lifecycle listener leaks

### DIFF
--- a/src/components/services/content/ServiceWebview.tsx
+++ b/src/components/services/content/ServiceWebview.tsx
@@ -1,5 +1,11 @@
 import { join } from 'node:path';
-import { action, makeObservable, observable, reaction } from 'mobx';
+import {
+  type IReactionDisposer,
+  action,
+  makeObservable,
+  observable,
+  reaction,
+} from 'mobx';
 import { observer } from 'mobx-react';
 import { Component, type ReactElement } from 'react';
 import ElectronWebView from 'react-electron-web-view';
@@ -7,6 +13,8 @@ import type ServiceModel from '../../../models/Service';
 import type { RealStores } from '../../../stores';
 
 const debug = require('../../../preload-safe-debug')('Ferdium:Services');
+
+type WebviewElement = ElectronWebView['view'];
 
 interface IProps {
   service: ServiceModel;
@@ -23,41 +31,74 @@ interface IProps {
 class ServiceWebview extends Component<IProps> {
   @observable webview: ElectronWebView | null = null;
 
+  private webviewReactionDisposer: IReactionDisposer;
+
+  private didAttachTimeout: ReturnType<typeof setTimeout> | null = null;
+
   constructor(props: IProps) {
     super(props);
 
-    this.refocusWebview = this.refocusWebview.bind(this);
     this._setWebview = this._setWebview.bind(this);
 
     makeObservable(this);
 
-    reaction(
-      () => this.webview,
-      () => {
-        if (this.webview?.view) {
-          this.webview.view.addEventListener('console-message', e => {
-            debug('Service logged a message:', e.message);
-          });
-          this.webview.view.addEventListener('did-navigate', () => {
-            if (this.props.service._webview) {
-              document.title = `Ferdium - ${this.props.service.name} ${
-                this.props.service.dialogTitle
-                  ? ` - ${this.props.service.dialogTitle}`
-                  : ''
-              } ${`- ${this.props.service._webview.getTitle()}`}`;
-            }
-          });
-        }
+    this.webviewReactionDisposer = reaction(
+      () => this.webview?.view ?? null,
+      (webview, previousWebview) => {
+        this.removeWebviewEventListeners(previousWebview);
+        this.addWebviewEventListeners(webview);
       },
     );
   }
 
   componentWillUnmount(): void {
     const { service, detachService } = this.props;
+    this.webviewReactionDisposer();
+    this.removeWebviewEventListeners(this.webview?.view ?? null);
+    if (this.didAttachTimeout) {
+      clearTimeout(this.didAttachTimeout);
+      this.didAttachTimeout = null;
+    }
     detachService({ service });
   }
 
-  refocusWebview(): void {
+  handleConsoleMessage = (e): void => {
+    debug('Service logged a message:', e.message);
+  };
+
+  handleDidNavigate = (): void => {
+    if (this.props.service._webview) {
+      document.title = `Ferdium - ${this.props.service.name} ${
+        this.props.service.dialogTitle
+          ? ` - ${this.props.service.dialogTitle}`
+          : ''
+      } ${`- ${this.props.service._webview.getTitle()}`}`;
+    }
+  };
+
+  handleWebviewRef = (webview: ElectronWebView | null): void => {
+    this._setWebview(webview);
+  };
+
+  handleDidAttach = (): void => {
+    const { service, setWebviewReference } = this.props;
+
+    // Force the event handler to run in a new task.
+    // This resolves a race condition when the `did-attach` is called,
+    // but the webview is not attached to the DOM yet:
+    // https://github.com/electron/electron/issues/31918
+    // This prevents us from immediately attaching listeners such as `did-stop-load`:
+    // https://github.com/ferdium/ferdium-app/issues/157
+    this.didAttachTimeout = setTimeout(() => {
+      setWebviewReference({
+        serviceId: service.id,
+        webview: this.webview?.view ?? null,
+      });
+      this.didAttachTimeout = null;
+    }, 0);
+  };
+
+  refocusWebview = (): void => {
     const { webview } = this;
     debug('Refocus Webview is called', this.props.service);
     if (!webview) {
@@ -77,15 +118,34 @@ class ServiceWebview extends Component<IProps> {
     } else {
       debug('Refocus not required - Not active service');
     }
+  };
+
+  addWebviewEventListeners(webview: WebviewElement | null): void {
+    if (!webview) {
+      return;
+    }
+
+    webview.addEventListener('console-message', this.handleConsoleMessage);
+    webview.addEventListener('did-navigate', this.handleDidNavigate);
+    webview.addEventListener('did-stop-loading', this.refocusWebview);
   }
 
-  @action _setWebview(webview): void {
+  removeWebviewEventListeners(webview: WebviewElement | null): void {
+    if (!webview) {
+      return;
+    }
+
+    webview.removeEventListener('console-message', this.handleConsoleMessage);
+    webview.removeEventListener('did-navigate', this.handleDidNavigate);
+    webview.removeEventListener('did-stop-loading', this.refocusWebview);
+  }
+
+  @action _setWebview(webview: ElectronWebView | null): void {
     this.webview = webview;
   }
 
   render(): ReactElement {
-    const { service, setWebviewReference, isSpellcheckerEnabled, stores } =
-      this.props;
+    const { service, isSpellcheckerEnabled, stores } = this.props;
 
     const { sandboxServices } = stores!.settings.app;
 
@@ -112,35 +172,14 @@ class ServiceWebview extends Component<IProps> {
 
     return (
       <ElectronWebView
-        ref={webview => {
-          this._setWebview(webview);
-          if (webview?.view) {
-            webview.view.addEventListener(
-              'did-stop-loading',
-              this.refocusWebview,
-            );
-          }
-        }}
+        ref={this.handleWebviewRef}
         autosize
         src={service.url}
         preload={preloadScript}
         partition={
           sandboxServices ? checkForSandbox() : 'persist:general-session'
         }
-        onDidAttach={() => {
-          // Force the event handler to run in a new task.
-          // This resolves a race condition when the `did-attach` is called,
-          // but the webview is not attached to the DOM yet:
-          // https://github.com/electron/electron/issues/31918
-          // This prevents us from immediately attaching listeners such as `did-stop-load`:
-          // https://github.com/ferdium/ferdium-app/issues/157
-          setTimeout(() => {
-            setWebviewReference({
-              serviceId: service.id,
-              webview: this.webview.view,
-            });
-          }, 0);
-        }}
+        onDidAttach={this.handleDidAttach}
         // onUpdateTargetUrl={this.updateTargetUrl} // TODO: [TS DEBT] need to check where its from
         useragent={service.userAgent}
         disablewebsecurity={

--- a/src/features/webControls/containers/WebControlsScreen.tsx
+++ b/src/features/webControls/containers/WebControlsScreen.tsx
@@ -1,9 +1,9 @@
 import {
   type IReactionDisposer,
   action,
-  autorun,
   makeObservable,
   observable,
+  reaction,
 } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import { Component, type ReactElement } from 'react';
@@ -35,9 +35,9 @@ class WebControlsScreen extends Component<IProps> {
 
   webview: ElectronWebView | null = null;
 
-  autorunDisposer: IReactionDisposer | null = null;
+  webviewReactionDisposer: IReactionDisposer | null = null;
 
-  constructor(props) {
+  constructor(props: IProps) {
     super(props);
 
     makeObservable(this);
@@ -46,31 +46,54 @@ class WebControlsScreen extends Component<IProps> {
   componentDidMount(): void {
     const { service } = this.props;
 
-    this.autorunDisposer = autorun(() => {
-      if (service.isAttached) {
-        this.webview = service.webview;
-        this._setUrl(this.webview.getURL());
-
-        for (const event of URL_EVENTS) {
-          this.webview.addEventListener(event, this.handleWebviewEvent);
-        }
-      }
-    });
+    this.webviewReactionDisposer = reaction(
+      () => (service.isAttached ? service.webview : null),
+      webview => this.setWebview(webview),
+      { fireImmediately: true },
+    );
   }
 
   componentWillUnmount(): void {
-    if (this.autorunDisposer) {
-      this.autorunDisposer();
+    if (this.webviewReactionDisposer) {
+      this.webviewReactionDisposer();
     }
 
-    if (this.webview) {
-      for (const event of URL_EVENTS) {
-        this.webview.removeEventListener(event, this.handleWebviewEvent);
-      }
+    this.setWebview(null);
+  }
+
+  addWebviewEventListeners(webview: ElectronWebView): void {
+    for (const event of URL_EVENTS) {
+      webview.addEventListener(event, this.handleWebviewEvent);
     }
   }
 
-  handleWebviewEvent = (e: any) => {
+  removeWebviewEventListeners(webview: ElectronWebView | null): void {
+    if (!webview) {
+      return;
+    }
+
+    for (const event of URL_EVENTS) {
+      webview.removeEventListener(event, this.handleWebviewEvent);
+    }
+  }
+
+  setWebview(webview: ElectronWebView | null): void {
+    if (this.webview === webview) {
+      return;
+    }
+
+    this.removeWebviewEventListeners(this.webview);
+    this.webview = webview;
+
+    if (!webview) {
+      return;
+    }
+
+    this._setUrlAndHistory(webview.getURL());
+    this.addWebviewEventListeners(webview);
+  }
+
+  handleWebviewEvent = (e: any): void => {
     if (!e.isMainFrame) {
       return;
     }
@@ -85,42 +108,47 @@ class WebControlsScreen extends Component<IProps> {
   @action
   _setUrlAndHistory(value): void {
     this._setUrl(value);
+    if (!this.webview) {
+      this.canGoBack = false;
+      this.canGoForward = false;
+      return;
+    }
     this.canGoBack = this.webview.canGoBack();
     this.canGoForward = this.webview.canGoForward();
   }
 
-  goHome(): void {
+  goHome = (): void => {
     if (!this.webview) {
       return;
     }
     this.webview.goToIndex(0);
-  }
+  };
 
-  reload(): void {
+  reload = (): void => {
     if (!this.webview) {
       return;
     }
 
     this.webview.reload();
-  }
+  };
 
-  goBack(): void {
+  goBack = (): void => {
     if (!this.webview) {
       return;
     }
 
     this.webview.goBack();
-  }
+  };
 
-  goForward(): void {
+  goForward = (): void => {
     if (!this.webview) {
       return;
     }
 
     this.webview.goForward();
-  }
+  };
 
-  navigate(url: string): void {
+  navigate = (url: string): void => {
     if (!this.webview) {
       return;
     }
@@ -142,28 +170,28 @@ class WebControlsScreen extends Component<IProps> {
 
     this.webview.loadURL(url);
     this._setUrl(url);
-  }
+  };
 
-  openInBrowser(): void {
+  openInBrowser = (): void => {
     const { openExternalUrl } = this.props.actions!.app;
     if (!this.webview) {
       return;
     }
 
     openExternalUrl({ url: this.url });
-  }
+  };
 
   render(): ReactElement {
     return (
       <WebControls
-        goHome={() => this.goHome()}
-        reload={() => this.reload()}
-        openInBrowser={() => this.openInBrowser()}
+        goHome={this.goHome}
+        reload={this.reload}
+        openInBrowser={this.openInBrowser}
         canGoBack={this.canGoBack}
-        goBack={() => this.goBack()}
+        goBack={this.goBack}
         canGoForward={this.canGoForward}
-        goForward={() => this.goForward()}
-        navigate={url => this.navigate(url)}
+        goForward={this.goForward}
+        navigate={this.navigate}
         url={this.url}
       />
     );

--- a/src/models/DownloadController.ts
+++ b/src/models/DownloadController.ts
@@ -66,8 +66,41 @@ type DownloadControllerOptions = {
   getAppActions?: () => DownloadActions;
 };
 
+type DownloadSessionLike = {
+  on: (
+    eventName: 'will-download',
+    listener: (...args: any[]) => void,
+  ) => unknown;
+};
+
+type DownloadWebContentsLike = {
+  id?: number;
+  session: DownloadSessionLike;
+  getId?: () => number;
+  once?: (eventName: 'destroyed', listener: () => void) => unknown;
+};
+
+type SessionDownloadListener = (
+  event: { preventDefault: () => void },
+  item: DownloadItemLike,
+  webContents?: DownloadWebContentsLike,
+) => void;
+
 export default class DownloadController {
   private activeDownloads = new Map<string, DownloadItemLike>();
+
+  private registeredSessions = new WeakSet<DownloadSessionLike>();
+
+  private sessionDownloadListeners = new WeakMap<
+    DownloadSessionLike,
+    SessionDownloadListener
+  >();
+
+  private sessionServiceIds = new WeakMap<DownloadSessionLike, Set<string>>();
+
+  private webContentsServiceIds = new Map<number, string>();
+
+  private sessionRegistrationCount = 0;
 
   private isListeningForIpc = false;
 
@@ -89,6 +122,35 @@ export default class DownloadController {
 
   get activeDownloadCount(): number {
     return this.activeDownloads.size;
+  }
+
+  get registeredSessionCount(): number {
+    return this.sessionRegistrationCount;
+  }
+
+  registerWebContents({
+    serviceId,
+    webContents,
+  }: {
+    serviceId: string;
+    webContents: DownloadWebContentsLike;
+  }): void {
+    this.registerSession(webContents.session);
+    this.registerServiceIdForSession(webContents.session, serviceId);
+
+    const webContentsId = this.getWebContentsId(webContents);
+    if (webContentsId === null) {
+      return;
+    }
+
+    this.webContentsServiceIds.set(webContentsId, serviceId);
+    webContents.once?.('destroyed', () => {
+      this.unregisterWebContents(webContentsId);
+    });
+  }
+
+  unregisterWebContents(webContentsId: number): void {
+    this.webContentsServiceIds.delete(webContentsId);
   }
 
   trackDownload({
@@ -179,7 +241,91 @@ export default class DownloadController {
     }
 
     this.activeDownloads.clear();
+    this.webContentsServiceIds.clear();
+    this.registeredSessions = new WeakSet<DownloadSessionLike>();
+    this.sessionDownloadListeners = new WeakMap<
+      DownloadSessionLike,
+      SessionDownloadListener
+    >();
+    this.sessionServiceIds = new WeakMap<DownloadSessionLike, Set<string>>();
+    this.sessionRegistrationCount = 0;
   }
+
+  private registerSession(session: DownloadSessionLike): void {
+    if (this.registeredSessions.has(session)) {
+      return;
+    }
+
+    const listener: SessionDownloadListener = (event, item, webContents) => {
+      this.handleWillDownload(session, event, item, webContents);
+    };
+
+    session.on('will-download', listener);
+    this.registeredSessions.add(session);
+    this.sessionDownloadListeners.set(session, listener);
+    this.sessionRegistrationCount += 1;
+  }
+
+  private registerServiceIdForSession(
+    session: DownloadSessionLike,
+    serviceId: string,
+  ): void {
+    const serviceIds = this.sessionServiceIds.get(session) ?? new Set<string>();
+    serviceIds.add(serviceId);
+    this.sessionServiceIds.set(session, serviceIds);
+  }
+
+  private getWebContentsId(
+    webContents: DownloadWebContentsLike | undefined,
+  ): number | null {
+    if (!webContents) {
+      return null;
+    }
+
+    if (typeof webContents.id === 'number') {
+      return webContents.id;
+    }
+
+    if (typeof webContents.getId === 'function') {
+      return webContents.getId();
+    }
+
+    return null;
+  }
+
+  private getServiceIdForDownload(
+    session: DownloadSessionLike,
+    webContents: DownloadWebContentsLike | undefined,
+  ): string {
+    const webContentsId = this.getWebContentsId(webContents);
+    if (webContentsId !== null) {
+      const serviceId = this.webContentsServiceIds.get(webContentsId);
+      if (serviceId) {
+        return serviceId;
+      }
+    }
+
+    const serviceIds = this.sessionServiceIds.get(session);
+    if (serviceIds?.size === 1) {
+      return [...serviceIds][0];
+    }
+
+    return '';
+  }
+
+  private handleWillDownload = (
+    session: DownloadSessionLike,
+    event: { preventDefault: () => void },
+    item: DownloadItemLike,
+    webContents?: DownloadWebContentsLike,
+  ): void => {
+    event.preventDefault();
+
+    this.trackDownload({
+      item,
+      serviceId: this.getServiceIdForDownload(session, webContents),
+    });
+  };
 
   private ensureIpcListeners(): void {
     if (this.isListeningForIpc) {

--- a/src/models/DownloadController.ts
+++ b/src/models/DownloadController.ts
@@ -1,0 +1,249 @@
+import { basename } from 'node:path';
+import { ipcRenderer } from 'electron';
+import { v4 as uuidV4 } from 'uuid';
+
+const debug = require('../preload-safe-debug')('Ferdium:DownloadController');
+
+type DownloadActionPayload = {
+  id: string;
+  serviceId?: string;
+  filename?: string;
+  url?: string;
+  savePath?: string;
+  receivedBytes?: number;
+  totalBytes?: number;
+  state?: string;
+  paused?: boolean;
+};
+
+type DownloadActions = {
+  addDownload: (download: DownloadActionPayload) => void;
+  updateDownload: (download: DownloadActionPayload) => void;
+  endedDownload: (download: DownloadActionPayload) => void;
+  removeDownload: (downloadId: string) => void;
+};
+
+type DownloadIpcData = {
+  downloadId?: string;
+};
+
+type DownloadIpc = {
+  on: (channel: string, listener: (...args: any[]) => void) => unknown;
+  removeListener: (
+    channel: string,
+    listener: (...args: any[]) => void,
+  ) => unknown;
+};
+
+export type DownloadItemLike = {
+  addListener: (
+    eventName: 'updated',
+    listener: (_event: unknown, state: string) => void,
+  ) => unknown;
+  once: (
+    eventName: 'done',
+    listener: (_event: unknown, state: string) => void,
+  ) => unknown;
+  removeListener: (
+    eventName: 'updated',
+    listener: (_event: unknown, state: string) => void,
+  ) => unknown;
+  cancel: () => void;
+  getFilename: () => string;
+  getReceivedBytes: () => number;
+  getSavePath: () => string;
+  getState: () => string;
+  getTotalBytes: () => number;
+  getURL: () => string;
+  isPaused: () => boolean;
+  pause: () => void;
+  resume: () => void;
+};
+
+type DownloadControllerOptions = {
+  ipc?: DownloadIpc;
+  createDownloadId?: () => string;
+  getAppActions?: () => DownloadActions;
+};
+
+export default class DownloadController {
+  private activeDownloads = new Map<string, DownloadItemLike>();
+
+  private isListeningForIpc = false;
+
+  private readonly ipc: DownloadIpc;
+
+  private readonly createDownloadId: () => string;
+
+  private readonly getAppActions: () => DownloadActions;
+
+  constructor({
+    ipc = ipcRenderer,
+    createDownloadId = uuidV4,
+    getAppActions = () => window['ferdium'].actions.app,
+  }: DownloadControllerOptions = {}) {
+    this.ipc = ipc;
+    this.createDownloadId = createDownloadId;
+    this.getAppActions = getAppActions;
+  }
+
+  get activeDownloadCount(): number {
+    return this.activeDownloads.size;
+  }
+
+  trackDownload({
+    item,
+    serviceId,
+  }: {
+    item: DownloadItemLike;
+    serviceId: string;
+  }): string {
+    this.ensureIpcListeners();
+
+    const downloadId = this.createDownloadId();
+    const actions = this.getAppActions();
+
+    this.activeDownloads.set(downloadId, item);
+
+    actions.addDownload({
+      id: downloadId,
+      serviceId,
+      filename: item.getFilename(),
+      url: item.getURL(),
+      savePath: item.getSavePath(),
+    });
+
+    const handleUpdated = (_event: unknown, state: string) => {
+      if (state === 'interrupted') {
+        debug('Download is interrupted but can be resumed');
+      } else if (state === 'progressing') {
+        if (item.isPaused()) {
+          debug('Download is paused');
+        } else {
+          debug(`Received bytes: ${item.getReceivedBytes()}`);
+        }
+      }
+
+      actions.updateDownload({
+        id: downloadId,
+        serviceId,
+        filename: basename(item.getSavePath()),
+        url: item.getURL(),
+        savePath: item.getSavePath(),
+        receivedBytes: item.getReceivedBytes(),
+        totalBytes: item.getTotalBytes(),
+        state,
+      });
+      debug('download updated', state);
+    };
+
+    const handleDone = (_event: unknown, state: string) => {
+      debug('download done', state);
+
+      item.removeListener('updated', handleUpdated);
+      this.activeDownloads.delete(downloadId);
+
+      if (state === 'completed') {
+        debug('Download successfully');
+      } else {
+        if (state === 'cancelled' && item.getSavePath() === '') {
+          actions.removeDownload(downloadId);
+          debug('Download is cancelled');
+        }
+        debug(`Download failed: ${state}`);
+      }
+
+      actions.endedDownload({
+        id: downloadId,
+        serviceId,
+        receivedBytes: item.getReceivedBytes(),
+        totalBytes: item.getTotalBytes(),
+        state,
+      });
+    };
+
+    item.addListener('updated', handleUpdated);
+    item.once('done', handleDone);
+
+    return downloadId;
+  }
+
+  dispose(): void {
+    if (this.isListeningForIpc) {
+      this.ipc.removeListener(
+        'toggle-pause-download',
+        this.handleTogglePauseDownload,
+      );
+      this.ipc.removeListener('stop-download', this.handleStopDownload);
+      this.isListeningForIpc = false;
+    }
+
+    this.activeDownloads.clear();
+  }
+
+  private ensureIpcListeners(): void {
+    if (this.isListeningForIpc) {
+      return;
+    }
+
+    this.ipc.on('toggle-pause-download', this.handleTogglePauseDownload);
+    this.ipc.on('stop-download', this.handleStopDownload);
+    this.isListeningForIpc = true;
+  }
+
+  private getTargetDownloads(
+    downloadId: string | undefined,
+  ): DownloadItemLike[] {
+    if (!downloadId) {
+      return [...this.activeDownloads.values()];
+    }
+
+    const item = this.activeDownloads.get(downloadId);
+    return item ? [item] : [];
+  }
+
+  private handleTogglePauseDownload = (
+    _event: unknown,
+    data?: DownloadIpcData,
+  ): void => {
+    const targetDownloads = this.getTargetDownloads(data?.downloadId);
+
+    for (const item of targetDownloads) {
+      debug('toggle-pause-download', item.isPaused(), item.getState());
+      if (item.isPaused()) {
+        item.resume();
+      } else {
+        item.pause();
+      }
+      debug('toggle-pause-download', item.isPaused(), item.getState());
+
+      this.getAppActions().updateDownload({
+        id: this.getDownloadId(item),
+        paused: item.isPaused(),
+      });
+    }
+  };
+
+  private handleStopDownload = (
+    _event: unknown,
+    data?: DownloadIpcData,
+  ): void => {
+    const targetDownloads = this.getTargetDownloads(data?.downloadId);
+
+    for (const item of targetDownloads) {
+      item.cancel();
+    }
+  };
+
+  private getDownloadId(downloadItem: DownloadItemLike): string {
+    for (const [downloadId, item] of this.activeDownloads) {
+      if (item === downloadItem) {
+        return downloadId;
+      }
+    }
+
+    return '';
+  }
+}
+
+export const downloadController = new DownloadController();

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -1,10 +1,9 @@
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { webContents } from '@electron/remote';
 import { ipcRenderer } from 'electron';
 import { action, autorun, computed, makeObservable, observable } from 'mobx';
 import type ElectronWebView from 'react-electron-web-view';
 
-import { v4 as uuidV4 } from 'uuid';
 import { needsToken } from '../api/apiBase';
 import { DEFAULT_SERVICE_ORDER, DEFAULT_SERVICE_SETTINGS } from '../config';
 import { isMac } from '../environment';
@@ -12,6 +11,7 @@ import { todosStore } from '../features/todos';
 import { getFaviconUrl } from '../helpers/favicon-helpers';
 import { isValidExternalURL, normalizedUrl } from '../helpers/url-helpers';
 import { ifUndefined } from '../jsUtils';
+import { downloadController } from './DownloadController';
 import type { IRecipe } from './Recipe';
 import UserAgent from './UserAgent';
 
@@ -610,79 +610,9 @@ export default class Service {
       webviewWebContents.session.on('will-download', (event, item) => {
         event.preventDefault();
 
-        const downloadId = uuidV4();
-
-        window['ferdium'].actions.app.addDownload({
-          id: downloadId,
+        downloadController.trackDownload({
+          item,
           serviceId: this.id,
-          filename: item.getFilename(),
-          url: item.getURL(),
-          savePath: item.getSavePath(),
-        });
-
-        item.addListener('updated', (event, state) => {
-          if (state === 'interrupted') {
-            debug('Download is interrupted but can be resumed');
-          } else if (state === 'progressing') {
-            if (item.isPaused()) {
-              debug('Download is paused');
-            } else {
-              debug(`Received bytes: ${item.getReceivedBytes()}`);
-            }
-          }
-          window['ferdium'].actions.app.updateDownload({
-            id: downloadId,
-            serviceId: this.id,
-            filename: basename(item.getSavePath()),
-            url: item.getURL(),
-            savePath: item.getSavePath(),
-            receivedBytes: item.getReceivedBytes(),
-            totalBytes: item.getTotalBytes(),
-            state,
-          });
-          debug('download updated', event, state);
-        });
-        item.addListener('done', (event, state) => {
-          debug('download done', event, state);
-          if (state === 'completed') {
-            debug('Download successfully');
-          } else {
-            if (state === 'cancelled' && item.getSavePath() === '') {
-              window['ferdium'].actions.app.removeDownload(downloadId);
-              debug('Download is cancelled');
-            }
-            debug(`Download failed: ${state}`);
-          }
-
-          window['ferdium'].actions.app.endedDownload({
-            id: downloadId,
-            serviceId: this.id,
-            receivedBytes: item.getReceivedBytes(),
-            totalBytes: item.getTotalBytes(),
-            state,
-          });
-        });
-
-        ipcRenderer.on('toggle-pause-download', (_, data) => {
-          debug('toggle-pause-download', item.isPaused(), item.getState());
-          if (data.downloadId === downloadId || data.downloadId === undefined) {
-            if (item.isPaused()) {
-              item.resume();
-            } else {
-              item.pause();
-            }
-          }
-          debug('toggle-pause-download', item.isPaused(), item.getState());
-          window['ferdium'].actions.app.updateDownload({
-            id: downloadId,
-            paused: item.isPaused(),
-          });
-        });
-
-        ipcRenderer.on('stop-download', (_, data) => {
-          if (data === undefined || downloadId === data.downloadId) {
-            item.cancel();
-          }
         });
       });
       webviewWebContents.on('login', (event, _, authInfo, callback) => {

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -461,6 +461,10 @@ export default class Service {
       return;
     }
     this.userAgentModel.setWebviewReference(webview);
+    downloadController.registerWebContents({
+      serviceId: this.id,
+      webContents: webviewWebContents,
+    });
     // If the recipe has implemented 'modifyRequestHeaders',
     // Send those headers to ipcMain so that it can be set in session
     if (typeof this.recipe.modifyRequestHeaders === 'function') {
@@ -606,15 +610,6 @@ export default class Service {
           }
         });
       }
-
-      webviewWebContents.session.on('will-download', (event, item) => {
-        event.preventDefault();
-
-        downloadController.trackDownload({
-          item,
-          serviceId: this.id,
-        });
-      });
       webviewWebContents.on('login', (event, _, authInfo, callback) => {
         // const authCallback = callback;
         debug('browser login event', authInfo);

--- a/src/models/UserAgent.ts
+++ b/src/models/UserAgent.ts
@@ -9,7 +9,7 @@ export default class UserAgent {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _didNavigateListener = (_event: any): void => {};
 
-  @observable.ref webview: ElectronWebView = null;
+  @observable.ref webview: ElectronWebView | null = null;
 
   @observable userAgentPref: string | null = null;
 
@@ -68,7 +68,11 @@ export default class UserAgent {
     return this.serviceUserAgentPref || this.defaultUserAgent;
   }
 
-  @action setWebviewReference(webview: ElectronWebView): void {
+  @action setWebviewReference(webview: ElectronWebView | null): void {
+    if (this.webview === webview) {
+      return;
+    }
+
     this.webview = webview;
   }
 
@@ -81,12 +85,16 @@ export default class UserAgent {
       // webview.userAgent during a pending navigation or redirect chain causes
       // Electron to cancel the navigation via SetUserAgentOverride(), which breaks
       // cross-origin form POST requests (e.g. SAML ACS endpoints) and redirect chains.
-      this.webview.userAgent =
-        this.serviceUserAgentPref || this.userAgentWithoutChromeVersion;
+      if (this.webview) {
+        this.webview.userAgent =
+          this.serviceUserAgentPref || this.userAgentWithoutChromeVersion;
+      }
     } else {
       debug('Setting user agent to default for url', url);
-      this.webview.userAgent =
-        this.serviceUserAgentPref || this.defaultUserAgent;
+      if (this.webview) {
+        this.webview.userAgent =
+          this.serviceUserAgentPref || this.defaultUserAgent;
+      }
     }
   }
 

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -747,6 +747,7 @@ export default class ServicesStore extends TypedStore {
   }
 
   @action _detachService({ service }) {
+    service.userAgentModel.setWebviewReference(null);
     // eslint-disable-next-line no-param-reassign
     service.webview = null;
     // eslint-disable-next-line no-param-reassign

--- a/src/webview/AutomaticLanguageDetection.ts
+++ b/src/webview/AutomaticLanguageDetection.ts
@@ -1,0 +1,132 @@
+import { debounce } from 'lodash';
+
+const DEFAULT_DETECTION_DELAY = 225;
+
+type DebouncedKeyupHandler = ((event: KeyboardEvent) => void) & {
+  cancel?: () => void;
+};
+
+type AutomaticLanguageDetectionOptions = {
+  detectLanguage: (sample: string) => Promise<string | null>;
+  getServiceId: () => string;
+  resolveSpellcheckerLocale: (locale: string) => string | null;
+  switchDictionary: (locale: string, serviceId: string) => void;
+  addKeyupListener?: (listener: (event: KeyboardEvent) => void) => void;
+  delay?: number;
+  removeKeyupListener?: (listener: (event: KeyboardEvent) => void) => void;
+};
+
+export default class AutomaticLanguageDetection {
+  private readonly addKeyupListener: (
+    listener: (event: KeyboardEvent) => void,
+  ) => void;
+
+  private readonly delay: number;
+
+  private readonly detectLanguage: (sample: string) => Promise<string | null>;
+
+  private readonly getServiceId: () => string;
+
+  private readonly removeKeyupListener: (
+    listener: (event: KeyboardEvent) => void,
+  ) => void;
+
+  private readonly resolveSpellcheckerLocale: (locale: string) => string | null;
+
+  private readonly switchDictionary: (
+    locale: string,
+    serviceId: string,
+  ) => void;
+
+  private handler: DebouncedKeyupHandler | null = null;
+
+  private attached = false;
+
+  constructor({
+    addKeyupListener = listener => window.addEventListener('keyup', listener),
+    delay = DEFAULT_DETECTION_DELAY,
+    detectLanguage,
+    getServiceId,
+    removeKeyupListener = listener =>
+      window.removeEventListener('keyup', listener),
+    resolveSpellcheckerLocale,
+    switchDictionary,
+  }: AutomaticLanguageDetectionOptions) {
+    this.addKeyupListener = addKeyupListener;
+    this.delay = delay;
+    this.detectLanguage = detectLanguage;
+    this.getServiceId = getServiceId;
+    this.removeKeyupListener = removeKeyupListener;
+    this.resolveSpellcheckerLocale = resolveSpellcheckerLocale;
+    this.switchDictionary = switchDictionary;
+  }
+
+  get isAttached(): boolean {
+    return this.attached;
+  }
+
+  enable(): void {
+    if (this.attached) {
+      return;
+    }
+
+    if (!this.handler) {
+      this.handler = debounce(this.detectLanguageFromEvent, this.delay);
+    }
+
+    this.addKeyupListener(this.handler);
+    this.attached = true;
+  }
+
+  disable(): void {
+    if (!this.attached || !this.handler) {
+      return;
+    }
+
+    this.removeKeyupListener(this.handler);
+    this.handler.cancel?.();
+    this.attached = false;
+  }
+
+  destroy(): void {
+    this.disable();
+    this.handler = null;
+  }
+
+  private detectLanguageFromEvent = async (
+    event: KeyboardEvent,
+  ): Promise<void> => {
+    const value = this.getValueFromEvent(event);
+
+    // Force a minimum length to get better detection results
+    if (value.length < 25) return;
+
+    const locale = await this.detectLanguage(value);
+    if (!locale) {
+      return;
+    }
+
+    const spellcheckerLocale = this.resolveSpellcheckerLocale(locale);
+    if (spellcheckerLocale) {
+      this.switchDictionary(spellcheckerLocale, this.getServiceId());
+    }
+  };
+
+  private getValueFromEvent(event: KeyboardEvent): string {
+    const element = event.target as
+      | (EventTarget & {
+          isContentEditable?: boolean;
+          textContent?: string | null;
+          value?: string;
+        })
+      | null;
+
+    if (!element) return '';
+
+    if (element.isContentEditable) {
+      return element.textContent ?? '';
+    }
+
+    return element.value ?? '';
+  }
+}

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -9,9 +9,10 @@ import {
 } from 'darkreader';
 import { contextBridge, ipcRenderer } from 'electron';
 import { pathExistsSync, readFileSync } from 'fs-extra';
-import { debounce, noop } from 'lodash';
+import { noop } from 'lodash';
 import { autorun, computed, makeObservable, observable } from 'mobx';
 
+import AutomaticLanguageDetection from './AutomaticLanguageDetection';
 import customDarkModeCss from './darkmode/custom';
 import ignoreList from './darkmode/ignore';
 
@@ -209,6 +210,16 @@ class RecipeController {
 
   findInPage: FindInPage | null = null;
 
+  automaticLanguageDetection = new AutomaticLanguageDetection({
+    detectLanguage: sample =>
+      ipcRenderer.invoke('detect-language', {
+        sample,
+      }),
+    getServiceId: () => this.settings.service.id,
+    resolveSpellcheckerLocale: getSpellcheckerLocaleByFuzzyIdentifier,
+    switchDictionary: switchDict,
+  });
+
   async initialize() {
     for (const channel of Object.keys(this.ipcEvents)) {
       ipcRenderer.on(channel, (...args) => {
@@ -252,6 +263,12 @@ class RecipeController {
         window.history.forward();
       }
     });
+
+    window.addEventListener('unload', () => this.destroy(), { once: true });
+  }
+
+  destroy() {
+    this.automaticLanguageDetection.destroy();
   }
 
   loadRecipeModule(_event, config, recipe) {
@@ -349,16 +366,19 @@ class RecipeController {
       let { spellcheckerLanguage } = this;
       debug(`Setting spellchecker language to ${spellcheckerLanguage}`);
       if (spellcheckerLanguage.includes('automatic')) {
-        this.automaticLanguageDetection();
+        this.automaticLanguageDetection.enable();
         debug(
           'Found `automatic` locale, falling back to user locale until detected',
           this.settings.app.locale,
         );
         spellcheckerLanguage = this.settings.app.locale;
+      } else {
+        this.automaticLanguageDetection.disable();
       }
       switchDict(spellcheckerLanguage, this.settings.service.id);
     } else {
       debug('Disable spellchecker');
+      this.automaticLanguageDetection.disable();
     }
 
     if (!this.recipe) {
@@ -472,45 +492,6 @@ class RecipeController {
   serviceIdEcho(event) {
     debug('Received a service echo ping');
     event.sender.send('service-id', this.settings.service.id);
-  }
-
-  async automaticLanguageDetection() {
-    window.addEventListener(
-      'keyup',
-      debounce(async e => {
-        const element = e.target;
-
-        if (!element) return;
-
-        let value = '';
-        if (element.isContentEditable) {
-          value = element.textContent;
-        } else if (element.value) {
-          value = element.value;
-        }
-
-        // Force a minimum length to get better detection results
-        if (value.length < 25) return;
-
-        debug('Detecting language for', value);
-        const locale = await ipcRenderer.invoke('detect-language', {
-          sample: value,
-        });
-        if (!locale) {
-          return;
-        }
-
-        const spellcheckerLocale =
-          getSpellcheckerLocaleByFuzzyIdentifier(locale);
-        debug(
-          'Language detected reliably, setting spellchecker language to',
-          spellcheckerLocale,
-        );
-        if (spellcheckerLocale) {
-          switchDict(spellcheckerLocale, this.settings.service.id);
-        }
-      }, 225),
-    );
   }
 
   toggleToTalk() {

--- a/test/components/services/content/ServiceWebview.test.tsx
+++ b/test/components/services/content/ServiceWebview.test.tsx
@@ -1,0 +1,140 @@
+import type ServiceWebviewClass from '../../../../src/components/services/content/ServiceWebview';
+
+type Listener = (...args: any[]) => void;
+
+type MockWebviewElement = {
+  addEventListener: jest.Mock;
+  blur: jest.Mock;
+  focus: jest.Mock;
+  getTitle: jest.Mock;
+  listenerCount: (eventName: string) => number;
+  removeEventListener: jest.Mock;
+};
+
+function mockCreateDebugLogger() {
+  return jest.fn();
+}
+
+function mockObserver<T>(component: T): T {
+  return component;
+}
+
+function createMockWebviewElement(): MockWebviewElement {
+  const listeners = new Map<string, Listener[]>();
+
+  return {
+    addEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      eventListeners.push(listener);
+      listeners.set(eventName, eventListeners);
+    }),
+    blur: jest.fn(),
+    focus: jest.fn(),
+    getTitle: jest.fn(() => 'Page Title'),
+    listenerCount(eventName: string) {
+      return listeners.get(eventName)?.length ?? 0;
+    },
+    removeEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      listeners.set(
+        eventName,
+        eventListeners.filter(currentListener => currentListener !== listener),
+      );
+    }),
+  };
+}
+
+function createMockWebview(view: MockWebviewElement) {
+  return { view };
+}
+
+function createProps() {
+  const service = {
+    _webview: null,
+    dialogTitle: '',
+    id: 'service-a',
+    isActive: false,
+    name: 'Service A',
+  };
+
+  return {
+    detachService: jest.fn(),
+    isSpellcheckerEnabled: false,
+    service,
+    setWebviewReference: jest.fn(),
+  };
+}
+
+jest.mock('mobx-react', () => ({
+  observer: mockObserver,
+}));
+jest.mock('react-electron-web-view', () => 'webview');
+jest.mock('../../../../src/preload-safe-debug', () => mockCreateDebugLogger);
+
+const ServiceWebview = jest.requireActual<
+  typeof import('../../../../src/components/services/content/ServiceWebview')
+>('../../../../src/components/services/content/ServiceWebview').default;
+
+describe('ServiceWebview', () => {
+  it('moves webview listeners from old webview to replacement webview', () => {
+    const component = new ServiceWebview(
+      createProps() as any,
+    ) as ServiceWebviewClass;
+    const firstView = createMockWebviewElement();
+    const secondView = createMockWebviewElement();
+
+    component._setWebview(createMockWebview(firstView) as any);
+    component._setWebview(createMockWebview(secondView) as any);
+
+    expect(firstView.listenerCount('console-message')).toBe(0);
+    expect(firstView.listenerCount('did-navigate')).toBe(0);
+    expect(firstView.listenerCount('did-stop-loading')).toBe(0);
+    expect(secondView.listenerCount('console-message')).toBe(1);
+    expect(secondView.listenerCount('did-navigate')).toBe(1);
+    expect(secondView.listenerCount('did-stop-loading')).toBe(1);
+  });
+
+  it('does not duplicate listeners when the same webview is set twice', () => {
+    const component = new ServiceWebview(
+      createProps() as any,
+    ) as ServiceWebviewClass;
+    const view = createMockWebviewElement();
+    const webview = createMockWebview(view);
+
+    component._setWebview(webview as any);
+    component._setWebview(webview as any);
+
+    expect(view.listenerCount('console-message')).toBe(1);
+    expect(view.listenerCount('did-navigate')).toBe(1);
+    expect(view.listenerCount('did-stop-loading')).toBe(1);
+  });
+
+  it('removes listeners and detaches service on unmount', () => {
+    const props = createProps();
+    const component = new ServiceWebview(props as any) as ServiceWebviewClass;
+    const view = createMockWebviewElement();
+
+    component._setWebview(createMockWebview(view) as any);
+    component.componentWillUnmount();
+
+    expect(view.listenerCount('console-message')).toBe(0);
+    expect(view.listenerCount('did-navigate')).toBe(0);
+    expect(view.listenerCount('did-stop-loading')).toBe(0);
+    expect(props.detachService).toHaveBeenCalledWith({
+      service: props.service,
+    });
+  });
+
+  it('cancels a pending did-attach update on unmount', () => {
+    jest.useFakeTimers();
+    const props = createProps();
+    const component = new ServiceWebview(props as any) as ServiceWebviewClass;
+
+    component.handleDidAttach();
+    component.componentWillUnmount();
+    jest.runOnlyPendingTimers();
+
+    expect(props.setWebviewReference).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/test/features/webControls/containers/WebControlsScreen.test.tsx
+++ b/test/features/webControls/containers/WebControlsScreen.test.tsx
@@ -1,0 +1,210 @@
+import { action, makeObservable, observable } from 'mobx';
+import type WebControlsScreenClass from '../../../../src/features/webControls/containers/WebControlsScreen';
+
+const URL_EVENTS = [
+  'load-commit',
+  'will-navigate',
+  'did-navigate',
+  'did-navigate-in-page',
+];
+
+type Listener = (...args: any[]) => void;
+
+type MockWebview = {
+  addEventListener: jest.Mock;
+  canGoBack: jest.Mock;
+  canGoForward: jest.Mock;
+  emit: (eventName: string, ...args: any[]) => void;
+  getURL: jest.Mock;
+  goBack: jest.Mock;
+  goForward: jest.Mock;
+  goToIndex: jest.Mock;
+  listenerCount: (eventName: string) => number;
+  loadURL: jest.Mock;
+  reload: jest.Mock;
+  removeEventListener: jest.Mock;
+};
+
+class TestService {
+  @observable isAttached = false;
+
+  @observable.ref webview: MockWebview | null = null;
+
+  constructor() {
+    makeObservable(this);
+  }
+
+  @action attach(webview: MockWebview): void {
+    this.webview = webview;
+    this.isAttached = true;
+  }
+
+  @action detach(): void {
+    this.isAttached = false;
+    this.webview = null;
+  }
+}
+
+function mockInject() {
+  return function injectDecorator<T>(component: T): T {
+    return component;
+  };
+}
+
+function mockObserver<T>(component: T): T {
+  return component;
+}
+
+function createMockWebview(url = 'https://example.com'): MockWebview {
+  const listeners = new Map<string, Listener[]>();
+
+  return {
+    addEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      eventListeners.push(listener);
+      listeners.set(eventName, eventListeners);
+    }),
+    canGoBack: jest.fn(() => true),
+    canGoForward: jest.fn(() => false),
+    emit(eventName, ...args) {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener(...args);
+      }
+    },
+    getURL: jest.fn(() => url),
+    goBack: jest.fn(),
+    goForward: jest.fn(),
+    goToIndex: jest.fn(),
+    listenerCount(eventName: string) {
+      return listeners.get(eventName)?.length ?? 0;
+    },
+    loadURL: jest.fn(),
+    reload: jest.fn(),
+    removeEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      listeners.set(
+        eventName,
+        eventListeners.filter(currentListener => currentListener !== listener),
+      );
+    }),
+  };
+}
+
+function createProps(service: TestService) {
+  return {
+    actions: {
+      app: {
+        openExternalUrl: jest.fn(),
+      },
+    },
+    service,
+    stores: {
+      settings: {
+        app: {
+          searchEngine: 'google',
+        },
+      },
+    },
+  };
+}
+
+jest.mock('mobx-react', () => ({
+  inject: mockInject,
+  observer: mockObserver,
+}));
+jest.mock(
+  '../../../../src/features/webControls/components/WebControls',
+  () => 'WebControls',
+);
+
+const WebControlsScreen = jest.requireActual<
+  typeof import('../../../../src/features/webControls/containers/WebControlsScreen')
+>('../../../../src/features/webControls/containers/WebControlsScreen').default;
+
+describe('WebControlsScreen', () => {
+  it('moves URL listeners from old webview to replacement webview', () => {
+    const service = new TestService();
+    const component = new WebControlsScreen(
+      createProps(service) as any,
+    ) as WebControlsScreenClass;
+    const firstWebview = createMockWebview('https://first.example');
+    const secondWebview = createMockWebview('https://second.example');
+
+    component.componentDidMount();
+    service.attach(firstWebview);
+    service.attach(secondWebview);
+
+    for (const eventName of URL_EVENTS) {
+      expect(firstWebview.listenerCount(eventName)).toBe(0);
+      expect(secondWebview.listenerCount(eventName)).toBe(1);
+    }
+    expect(component.url).toBe('https://second.example');
+  });
+
+  it('does not duplicate URL listeners for the same webview', () => {
+    const service = new TestService();
+    const component = new WebControlsScreen(
+      createProps(service) as any,
+    ) as WebControlsScreenClass;
+    const webview = createMockWebview();
+
+    component.componentDidMount();
+    service.attach(webview);
+    service.attach(webview);
+
+    for (const eventName of URL_EVENTS) {
+      expect(webview.listenerCount(eventName)).toBe(1);
+    }
+  });
+
+  it('removes URL listeners when the service detaches', () => {
+    const service = new TestService();
+    const component = new WebControlsScreen(
+      createProps(service) as any,
+    ) as WebControlsScreenClass;
+    const webview = createMockWebview();
+
+    component.componentDidMount();
+    service.attach(webview);
+    service.detach();
+
+    for (const eventName of URL_EVENTS) {
+      expect(webview.listenerCount(eventName)).toBe(0);
+    }
+  });
+
+  it('removes URL listeners on unmount', () => {
+    const service = new TestService();
+    const component = new WebControlsScreen(
+      createProps(service) as any,
+    ) as WebControlsScreenClass;
+    const webview = createMockWebview();
+
+    component.componentDidMount();
+    service.attach(webview);
+    component.componentWillUnmount();
+
+    for (const eventName of URL_EVENTS) {
+      expect(webview.listenerCount(eventName)).toBe(0);
+    }
+  });
+
+  it('updates URL and navigation state from main-frame navigation events', () => {
+    const service = new TestService();
+    const component = new WebControlsScreen(
+      createProps(service) as any,
+    ) as WebControlsScreenClass;
+    const webview = createMockWebview();
+
+    component.componentDidMount();
+    service.attach(webview);
+    webview.emit('did-navigate', {
+      isMainFrame: true,
+      url: 'https://example.com/inbox',
+    });
+
+    expect(component.url).toBe('https://example.com/inbox');
+    expect(component.canGoBack).toBe(true);
+    expect(component.canGoForward).toBe(false);
+  });
+});

--- a/test/helpers/service-helpers.test.ts
+++ b/test/helpers/service-helpers.test.ts
@@ -1,3 +1,5 @@
+import type * as ServiceHelpersModule from '../../src/helpers/service-helpers';
+
 jest.mock('fs-extra', () => ({
   pathExistsSync: jest.fn(),
   readJsonSync: jest.fn(),
@@ -21,7 +23,7 @@ const {
   removeServicePartitionDirectory,
 } = jest.requireActual(
   '../../src/helpers/service-helpers',
-) as typeof import('../../src/helpers/service-helpers');
+) as typeof ServiceHelpersModule;
 
 const mockedPathExistsSync = jest.mocked(fsExtra.pathExistsSync);
 const mockedReadJsonSync = jest.mocked(fsExtra.readJsonSync);

--- a/test/models/DownloadController.test.ts
+++ b/test/models/DownloadController.test.ts
@@ -1,0 +1,259 @@
+import type * as DownloadControllerModule from '../../src/models/DownloadController';
+
+type Listener = (...args: any[]) => void;
+
+type MockIpc = {
+  emit: (channel: string, ...args: any[]) => void;
+  listenerCount: (channel: string) => number;
+  on: (channel: string, listener: Listener) => MockIpc;
+  removeListener: (channel: string, listener: Listener) => MockIpc;
+};
+
+type MockDownloadItem = {
+  cancelled: boolean;
+  paused: boolean;
+  addListener: (_eventName: 'updated', listener: Listener) => MockDownloadItem;
+  cancel: () => void;
+  emit: (eventName: string, ...args: any[]) => void;
+  getFilename: () => string;
+  getReceivedBytes: () => number;
+  getSavePath: () => string;
+  getState: () => string;
+  getTotalBytes: () => number;
+  getURL: () => string;
+  isPaused: () => boolean;
+  listenerCount: (eventName: string) => number;
+  once: (_eventName: 'done', listener: Listener) => MockDownloadItem;
+  pause: () => void;
+  removeListener: (
+    eventName: 'done' | 'updated',
+    listener: Listener,
+  ) => MockDownloadItem;
+  resume: () => void;
+};
+
+function createMockIpc(): MockIpc {
+  const listeners = new Map<string, Listener[]>();
+
+  const ipc: MockIpc = {
+    on(channel, listener) {
+      const channelListeners = listeners.get(channel) ?? [];
+      channelListeners.push(listener);
+      listeners.set(channel, channelListeners);
+      return ipc;
+    },
+    removeListener(channel, listener) {
+      const channelListeners = listeners.get(channel) ?? [];
+      listeners.set(
+        channel,
+        channelListeners.filter(
+          currentListener => currentListener !== listener,
+        ),
+      );
+      return ipc;
+    },
+    emit(channel, ...args) {
+      for (const listener of listeners.get(channel) ?? []) {
+        listener(...args);
+      }
+    },
+    listenerCount(channel) {
+      return listeners.get(channel)?.length ?? 0;
+    },
+  };
+
+  return ipc;
+}
+
+function mockElectron() {
+  return {
+    ipcRenderer: createMockIpc(),
+  };
+}
+
+jest.mock('electron', mockElectron);
+
+function mockDownloadControllerDebug() {
+  return jest.fn();
+}
+
+jest.mock('../../src/preload-safe-debug', () => mockDownloadControllerDebug);
+
+const { default: DownloadController } = jest.requireActual(
+  '../../src/models/DownloadController',
+) as typeof DownloadControllerModule;
+
+function createActions() {
+  return {
+    addDownload: jest.fn(),
+    updateDownload: jest.fn(),
+    endedDownload: jest.fn(),
+    removeDownload: jest.fn(),
+  };
+}
+
+function createMockDownloadItem(filename: string): MockDownloadItem {
+  const listeners = new Map<string, Listener[]>();
+
+  const item: MockDownloadItem = {
+    paused: false,
+    cancelled: false,
+    getFilename() {
+      return filename;
+    },
+    getURL() {
+      return `https://example.test/${filename}`;
+    },
+    getSavePath() {
+      return item.cancelled ? '' : `C:\\Downloads\\${filename}`;
+    },
+    getReceivedBytes() {
+      return 50;
+    },
+    getTotalBytes() {
+      return 100;
+    },
+    isPaused() {
+      return item.paused;
+    },
+    pause() {
+      item.paused = true;
+    },
+    resume() {
+      item.paused = false;
+    },
+    cancel() {
+      item.cancelled = true;
+    },
+    getState() {
+      return item.paused ? 'paused' : 'progressing';
+    },
+    addListener(_eventName, listener) {
+      const eventListeners = listeners.get('updated') ?? [];
+      eventListeners.push(listener);
+      listeners.set('updated', eventListeners);
+      return item;
+    },
+    once(_eventName, listener) {
+      const wrappedListener: Listener = (...args) => {
+        item.removeListener('done', wrappedListener);
+        listener(...args);
+      };
+      const eventListeners = listeners.get('done') ?? [];
+      eventListeners.push(wrappedListener);
+      listeners.set('done', eventListeners);
+      return item;
+    },
+    removeListener(eventName, listener) {
+      const eventListeners = listeners.get(eventName) ?? [];
+      listeners.set(
+        eventName,
+        eventListeners.filter(currentListener => currentListener !== listener),
+      );
+      return item;
+    },
+    emit(eventName, ...args) {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener(...args);
+      }
+    },
+    listenerCount(eventName) {
+      return listeners.get(eventName)?.length ?? 0;
+    },
+  };
+
+  return item;
+}
+
+function createController() {
+  const ipc = createMockIpc();
+  const actions = createActions();
+  let nextId = 0;
+  const controller = new DownloadController({
+    ipc,
+    createDownloadId: () => {
+      nextId += 1;
+      return `download-${nextId}`;
+    },
+    getAppActions: () => actions,
+  });
+
+  return { actions, controller, ipc };
+}
+
+describe('DownloadController', () => {
+  it('keeps one IPC listener per download command while tracking many downloads', () => {
+    const { controller, ipc } = createController();
+    const items = Array.from({ length: 100 }, (_, index) =>
+      createMockDownloadItem(`file-${index}.txt`),
+    );
+
+    for (const item of items) {
+      controller.trackDownload({
+        item,
+        serviceId: 'service-id',
+      });
+    }
+
+    expect(ipc.listenerCount('toggle-pause-download')).toBe(1);
+    expect(ipc.listenerCount('stop-download')).toBe(1);
+    expect(controller.activeDownloadCount).toBe(100);
+  });
+
+  it.each(['completed', 'cancelled', 'interrupted', 'failed'])(
+    'removes downloads and item listeners after %s terminal state',
+    state => {
+      const { actions, controller } = createController();
+      const item = createMockDownloadItem(`${state}.txt`);
+      const downloadId = controller.trackDownload({
+        item,
+        serviceId: 'service-id',
+      });
+
+      expect(controller.activeDownloadCount).toBe(1);
+      expect(item.listenerCount('updated')).toBe(1);
+
+      item.emit('done', {}, state);
+
+      expect(controller.activeDownloadCount).toBe(0);
+      expect(item.listenerCount('updated')).toBe(0);
+      expect(actions.endedDownload).toHaveBeenCalledWith({
+        id: downloadId,
+        serviceId: 'service-id',
+        receivedBytes: 50,
+        totalBytes: 100,
+        state,
+      });
+    },
+  );
+
+  it('pauses, resumes, and cancels only requested active downloads', () => {
+    const { actions, controller, ipc } = createController();
+    const first = createMockDownloadItem('first.txt');
+    const second = createMockDownloadItem('second.txt');
+    const firstId = controller.trackDownload({
+      item: first,
+      serviceId: 'service-id',
+    });
+    controller.trackDownload({
+      item: second,
+      serviceId: 'service-id',
+    });
+
+    ipc.emit('toggle-pause-download', {}, { downloadId: firstId });
+
+    expect(first.isPaused()).toBe(true);
+    expect(second.isPaused()).toBe(false);
+    expect(actions.updateDownload).toHaveBeenLastCalledWith({
+      id: firstId,
+      paused: true,
+    });
+
+    ipc.emit('toggle-pause-download', {}, { downloadId: firstId });
+    ipc.emit('stop-download', {}, { downloadId: firstId });
+
+    expect(first.isPaused()).toBe(false);
+    expect(first.cancelled).toBe(true);
+    expect(second.cancelled).toBe(false);
+  });
+});

--- a/test/models/DownloadController.test.ts
+++ b/test/models/DownloadController.test.ts
@@ -32,6 +32,13 @@ type MockDownloadItem = {
   resume: () => void;
 };
 
+type MockWebContents = {
+  id: number;
+  session: MockIpc;
+  destroy: () => void;
+  once: (eventName: 'destroyed', listener: Listener) => MockWebContents;
+};
+
 function createMockIpc(): MockIpc {
   const listeners = new Map<string, Listener[]>();
 
@@ -165,6 +172,29 @@ function createMockDownloadItem(filename: string): MockDownloadItem {
   return item;
 }
 
+function createMockWebContents(id: number, session: MockIpc): MockWebContents {
+  const listeners = new Map<string, Listener[]>();
+
+  const webContents: MockWebContents = {
+    id,
+    session,
+    once(eventName, listener) {
+      const eventListeners = listeners.get(eventName) ?? [];
+      eventListeners.push(listener);
+      listeners.set(eventName, eventListeners);
+      return webContents;
+    },
+    destroy() {
+      for (const listener of listeners.get('destroyed') ?? []) {
+        listener();
+      }
+      listeners.set('destroyed', []);
+    },
+  };
+
+  return webContents;
+}
+
 function createController() {
   const ipc = createMockIpc();
   const actions = createActions();
@@ -255,5 +285,105 @@ describe('DownloadController', () => {
     expect(first.isPaused()).toBe(false);
     expect(first.cancelled).toBe(true);
     expect(second.cancelled).toBe(false);
+  });
+
+  it('registers one download listener for webContents sharing a session', () => {
+    const { actions, controller } = createController();
+    const session = createMockIpc();
+    const firstWebContents = createMockWebContents(1, session);
+    const secondWebContents = createMockWebContents(2, session);
+    const event = { preventDefault: jest.fn() };
+    const item = createMockDownloadItem('shared-session.txt');
+
+    controller.registerWebContents({
+      serviceId: 'first-service',
+      webContents: firstWebContents,
+    });
+    controller.registerWebContents({
+      serviceId: 'second-service',
+      webContents: secondWebContents,
+    });
+
+    expect(session.listenerCount('will-download')).toBe(1);
+    expect(controller.registeredSessionCount).toBe(1);
+
+    session.emit('will-download', event, item, secondWebContents);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(actions.addDownload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'download-1',
+        serviceId: 'second-service',
+      }),
+    );
+  });
+
+  it('registers separate download listeners for separate custom sessions', () => {
+    const { actions, controller } = createController();
+    const firstSession = createMockIpc();
+    const secondSession = createMockIpc();
+    const firstWebContents = createMockWebContents(1, firstSession);
+    const secondWebContents = createMockWebContents(2, secondSession);
+
+    controller.registerWebContents({
+      serviceId: 'first-service',
+      webContents: firstWebContents,
+    });
+    controller.registerWebContents({
+      serviceId: 'second-service',
+      webContents: secondWebContents,
+    });
+
+    expect(firstSession.listenerCount('will-download')).toBe(1);
+    expect(secondSession.listenerCount('will-download')).toBe(1);
+    expect(controller.registeredSessionCount).toBe(2);
+
+    firstSession.emit(
+      'will-download',
+      { preventDefault: jest.fn() },
+      createMockDownloadItem('first-custom.txt'),
+      firstWebContents,
+    );
+    secondSession.emit(
+      'will-download',
+      { preventDefault: jest.fn() },
+      createMockDownloadItem('second-custom.txt'),
+      secondWebContents,
+    );
+
+    expect(actions.addDownload).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ serviceId: 'first-service' }),
+    );
+    expect(actions.addDownload).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ serviceId: 'second-service' }),
+    );
+  });
+
+  it('uses the service ID value rather than retaining a service object', () => {
+    const { actions, controller } = createController();
+    const session = createMockIpc();
+    const webContents = createMockWebContents(1, session);
+    const service = { id: 'service-before-mutation' };
+
+    controller.registerWebContents({
+      serviceId: service.id,
+      webContents,
+    });
+
+    service.id = 'service-after-mutation';
+    session.emit(
+      'will-download',
+      { preventDefault: jest.fn() },
+      createMockDownloadItem('lightweight-service-id.txt'),
+      webContents,
+    );
+
+    expect(actions.addDownload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'service-before-mutation',
+      }),
+    );
   });
 });

--- a/test/models/UserAgent.test.ts
+++ b/test/models/UserAgent.test.ts
@@ -1,0 +1,95 @@
+import UserAgent from '../../src/models/UserAgent';
+
+function mockCreateDebugLogger() {
+  return jest.fn();
+}
+
+jest.mock('../../src/preload-safe-debug', () => mockCreateDebugLogger);
+
+type Listener = (...args: any[]) => void;
+
+type MockWebview = {
+  userAgent: string;
+  addEventListener: jest.Mock;
+  emit: (eventName: string, ...args: any[]) => void;
+  listenerCount: (eventName: string) => number;
+  removeEventListener: jest.Mock;
+};
+
+function createMockWebview(): MockWebview {
+  const listeners = new Map<string, Listener[]>();
+
+  const webview: MockWebview = {
+    userAgent: '',
+    addEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      eventListeners.push(listener);
+      listeners.set(eventName, eventListeners);
+    }),
+    removeEventListener: jest.fn((eventName: string, listener: Listener) => {
+      const eventListeners = listeners.get(eventName) ?? [];
+      listeners.set(
+        eventName,
+        eventListeners.filter(currentListener => currentListener !== listener),
+      );
+    }),
+    emit(eventName, ...args) {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener(...args);
+      }
+    },
+    listenerCount(eventName) {
+      return listeners.get(eventName)?.length ?? 0;
+    },
+  };
+
+  return webview;
+}
+
+describe('UserAgent', () => {
+  it('moves navigation listener from old webview to replacement webview', () => {
+    const userAgent = new UserAgent(() => 'Default User Agent');
+    const firstWebview = createMockWebview();
+    const secondWebview = createMockWebview();
+
+    userAgent.setWebviewReference(firstWebview as any);
+    userAgent.setWebviewReference(secondWebview as any);
+
+    expect(firstWebview.addEventListener).toHaveBeenCalledTimes(1);
+    expect(firstWebview.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(firstWebview.removeEventListener).toHaveBeenCalledWith(
+      'did-navigate',
+      firstWebview.addEventListener.mock.calls[0][1],
+    );
+    expect(firstWebview.listenerCount('did-navigate')).toBe(0);
+    expect(secondWebview.addEventListener).toHaveBeenCalledTimes(1);
+    expect(secondWebview.listenerCount('did-navigate')).toBe(1);
+  });
+
+  it('does not attach duplicate listeners for the same webview', () => {
+    const userAgent = new UserAgent(() => 'Default User Agent');
+    const webview = createMockWebview();
+
+    userAgent.setWebviewReference(webview as any);
+    userAgent.setWebviewReference(webview as any);
+
+    expect(webview.addEventListener).toHaveBeenCalledTimes(1);
+    expect(webview.removeEventListener).not.toHaveBeenCalled();
+    expect(webview.listenerCount('did-navigate')).toBe(1);
+  });
+
+  it('removes listener and clears reference on detach', () => {
+    const userAgent = new UserAgent(() => 'Default User Agent');
+    const webview = createMockWebview();
+
+    userAgent.setWebviewReference(webview as any);
+    userAgent.setWebviewReference(null);
+
+    expect(webview.removeEventListener).toHaveBeenCalledWith(
+      'did-navigate',
+      webview.addEventListener.mock.calls[0][1],
+    );
+    expect(webview.listenerCount('did-navigate')).toBe(0);
+    expect(userAgent.webview).toBeNull();
+  });
+});

--- a/test/stores/ServicesStore.test.ts
+++ b/test/stores/ServicesStore.test.ts
@@ -1,0 +1,56 @@
+import type ServicesStoreClass from '../../src/stores/ServicesStore';
+
+function mockCreateDebugLogger() {
+  return jest.fn();
+}
+
+function mockFilterServicesByActiveWorkspace<T>(services: T): T {
+  return services;
+}
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: jest.fn(),
+    on: jest.fn(),
+    send: jest.fn(),
+  },
+  shell: {
+    openExternal: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/environment-remote', () => ({
+  ferdiumVersion: 'test-version',
+  userDataRecipesPath: (...segments: string[]) => segments.join('/'),
+}));
+
+jest.mock('../../src/features/workspaces', () => ({
+  workspaceStore: {
+    filterServicesByActiveWorkspace: mockFilterServicesByActiveWorkspace,
+  },
+}));
+jest.mock('../../src/preload-safe-debug', () => mockCreateDebugLogger);
+
+const ServicesStore = jest.requireActual<
+  typeof import('../../src/stores/ServicesStore')
+>('../../src/stores/ServicesStore').default;
+
+describe('ServicesStore', () => {
+  it('clears UserAgent webview reference when detaching a service', () => {
+    const store = Object.create(ServicesStore.prototype) as ServicesStoreClass;
+    const userAgentModel = {
+      setWebviewReference: jest.fn(),
+    };
+    const service = {
+      isAttached: true,
+      userAgentModel,
+      webview: { id: 'webview' },
+    };
+
+    store._detachService({ service });
+
+    expect(userAgentModel.setWebviewReference).toHaveBeenCalledWith(null);
+    expect(service.webview).toBeNull();
+    expect(service.isAttached).toBe(false);
+  });
+});

--- a/test/webview/AutomaticLanguageDetection.test.ts
+++ b/test/webview/AutomaticLanguageDetection.test.ts
@@ -1,0 +1,127 @@
+import AutomaticLanguageDetection from '../../src/webview/AutomaticLanguageDetection';
+
+function createController() {
+  const listeners: ((event: KeyboardEvent) => void)[] = [];
+  const detectLanguage = jest.fn().mockResolvedValue('pt');
+  const resolveSpellcheckerLocale = jest.fn().mockReturnValue('pt-PT');
+  const switchDictionary = jest.fn();
+  const addKeyupListener = jest.fn(
+    (listener: (event: KeyboardEvent) => void) => {
+      listeners.push(listener);
+    },
+  );
+  const removeKeyupListener = jest.fn(
+    (listener: (event: KeyboardEvent) => void) => {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    },
+  );
+
+  const controller = new AutomaticLanguageDetection({
+    addKeyupListener,
+    delay: 225,
+    detectLanguage,
+    getServiceId: () => 'service-id',
+    removeKeyupListener,
+    resolveSpellcheckerLocale,
+    switchDictionary,
+  });
+
+  return {
+    addKeyupListener,
+    controller,
+    detectLanguage,
+    listeners,
+    removeKeyupListener,
+    resolveSpellcheckerLocale,
+    switchDictionary,
+  };
+}
+
+describe('AutomaticLanguageDetection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('attaches one keyup listener across repeated enables', () => {
+    const { addKeyupListener, controller, listeners } = createController();
+
+    controller.enable();
+    controller.enable();
+    controller.enable();
+
+    expect(addKeyupListener).toHaveBeenCalledTimes(1);
+    expect(listeners).toHaveLength(1);
+    expect(controller.isAttached).toBe(true);
+  });
+
+  it('removes the same keyup listener when disabled', () => {
+    const { addKeyupListener, controller, listeners, removeKeyupListener } =
+      createController();
+
+    controller.enable();
+    const [handler] = listeners;
+
+    controller.disable();
+
+    expect(removeKeyupListener).toHaveBeenCalledTimes(1);
+    expect(removeKeyupListener).toHaveBeenCalledWith(handler);
+    expect(removeKeyupListener.mock.calls[0][0]).toBe(
+      addKeyupListener.mock.calls[0][0],
+    );
+    expect(listeners).toHaveLength(0);
+    expect(controller.isAttached).toBe(false);
+  });
+
+  it('destroys idempotently and cancels pending detection work', () => {
+    const { controller, detectLanguage, listeners } = createController();
+    const event = {
+      target: {
+        value: 'This is a long enough message to trigger detection.',
+      },
+    } as unknown as KeyboardEvent;
+
+    controller.enable();
+    listeners[0](event);
+
+    controller.destroy();
+    controller.destroy();
+    jest.advanceTimersByTime(225);
+
+    expect(detectLanguage).not.toHaveBeenCalled();
+    expect(controller.isAttached).toBe(false);
+  });
+
+  it('detects language once for a single keyup listener', async () => {
+    const {
+      controller,
+      detectLanguage,
+      listeners,
+      resolveSpellcheckerLocale,
+      switchDictionary,
+    } = createController();
+    const event = {
+      target: {
+        value: 'This is a long enough message to trigger detection.',
+      },
+    } as unknown as KeyboardEvent;
+
+    controller.enable();
+    listeners[0](event);
+    jest.advanceTimersByTime(225);
+    await Promise.resolve();
+
+    expect(detectLanguage).toHaveBeenCalledTimes(1);
+    expect(detectLanguage).toHaveBeenCalledWith(
+      'This is a long enough message to trigger detection.',
+    );
+    expect(resolveSpellcheckerLocale).toHaveBeenCalledWith('pt');
+    expect(switchDictionary).toHaveBeenCalledWith('pt-PT', 'service-id');
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
This PR fixes several confirmed listener/reference lifecycle leaks:

- De-duplicates download `will-download` handling by introducing a centralized `DownloadController`.
- Prevents per-download IPC listener duplication.
- Moves download session listeners away from service-owned closures.
- Prevents duplicate automatic language detection `keyup` listeners.
- Clears stale `UserAgent` webview references when a service detaches.
- Cleans up `ServiceWebview` reactions, webview event listeners, and pending attach timers.
- Cleans up WebControls webview URL listeners when webviews are replaced or detached.
- Adds regression tests for the fixed lifecycle paths.


#### Motivation and Context
These changes address confirmed Ferdium-side lifecycle issues found while investigating memory growth reports, including #2197.

The old code could retain service/webview objects through long-lived Electron sessions, window listeners, MobX reactions, and webview event listeners. The new code makes those listener owners explicit and removes listeners on replacement, detach, completion, or unmount.

Probably fixes #2197.

#### Screenshots
Only hibernation in 1 service test:
| Before | After |
|-- |-- |
| <img width="554" height="330" alt="image" src="https://github.com/user-attachments/assets/4778f770-11e6-4d5f-89a4-34af9999db8d" /> | <img width="552" height="334" alt="image" src="https://github.com/user-attachments/assets/a126538f-9462-4ecd-a7d6-c2eb6f218d66" /> |

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

<!-- Please add a one-line description for users of Ferdium to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
