### PR TITLE
fix(ci): restore automatic recipes submodule updates

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -73,8 +73,9 @@ jobs:
           # Defensive: update submodules in the develop branch
           git checkout develop
           git submodule update --init --recursive --remote --rebase --force
-          git add .
-          git commit -am "Update submodules [skip ci]" --no-verify || true
+          # Git 2.54+ requires --force and an explicit path for submodules with ignore=all.
+          git add --force recipes
+          git commit -m "Update submodules [skip ci]" --no-verify || true
           git push origin develop --no-verify
           git checkout -
 


### PR DESCRIPTION
## Pre-flight Checklist

Please ensure you've completed all of the following.

* [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md)(https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md)(https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.

## Description of Change

Fix the nightly workflow so that updates to the `recipes` submodule are staged and committed again.

The workflow previously updated the submodule with:

```sh
git submodule update --init --recursive --remote --rebase --force
```

and then relied on:

```sh
git add .
git commit -am "Update submodules [skip ci]" --no-verify
```

to stage and commit the new `recipes` gitlink.

This PR changes that to explicitly stage the recipes submodule:

```sh
git add --force recipes
git commit -m "Update submodules [skip ci]" --no-verify
```

This is intentionally limited to `recipes`; the other `git add .` in the workflow, which is used for unrelated generated/package maintenance changes, remains unchanged.

Removing `-a` from the submodule commit is also intentional. The commit now contains exactly the submodule reference that was explicitly staged rather than implicitly staging other modified tracked files.

## Motivation and Context

The automatic recipes update stopped working because of an upstream Git behavior change rather than a change in the Ferdium recipes repository or in `git submodule update`.

`recipes` is configured in `.gitmodules` with:

```ini
ignore = all
```

Historically, after `git submodule update --remote` moved the local `recipes` checkout to the latest commit, `git add .` would still stage the updated submodule gitlink in the parent repository.

Git changed this behavior in upstream commit:

https://github.com/git/git/commit/a16c4a245acb2420bafcbd572ba9fb94b1ba5146

The change is titled:

> `read-cache: submodule add need --force given ignore=all configuration`

With this change, submodules configured with `ignore=all` are skipped by `git add` unless:

1. the submodule path is explicitly specified, and
2. `--force` is supplied.

As a result, the existing workflow now behaves roughly as follows:

```text
git submodule update --remote
        ↓
recipes checkout moves to latest main commit
        ↓
git add .
        ↓
recipes is skipped because ignore=all
        ↓
no updated gitlink is staged
        ↓
git commit has no submodule update to commit
        ↓
develop continues pointing to the old recipes commit
```

This explains why the nightly workflow can run successfully while the recipes submodule reference in `ferdium-app` does not advance.

The updated command follows Git's new required behavior:

```sh
git add --force recipes
```

Explicitly naming `recipes` is important; using only `git add --force .` would not address the new semantics as precisely.

This keeps the existing `ignore = all` configuration intact, preserving its intended behavior for developers, while explicitly opting the CI workflow into updating the recipes gitlink.

## Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally