### PR TITLE
Fix crowdin update string as unapproved

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,7 @@ append_commit_message:
 files:
   - source: /src/i18n/locales/en-US.json
     translation: /src/i18n/locales/%two_letters_code%.json
+    update_option: update_as_unapproved
     languages_mapping:
       two_letters_code:
         nl-BE: nl-BE


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.
#### Description of Change

Adds `update_option: update_as_unapproved` to the Crowdin configuration.

This makes Crowdin preserve existing translations when an English source string is changed, while marking those translations as unapproved so they can be reviewed by translators.

Previously, changing an existing source string could cause Crowdin to remove its translations from the generated locale files.

#### Motivation and Context

In #1948, the `workspaceDrawer.item.contextMenuEdit` source string was changed from `edit` to `Edit`.

After that change, the Crowdin synchronization in #2482 started removing the corresponding translation key from multiple locale files instead of preserving the existing translations.

Setting:

```yaml
update_option: update_as_unapproved
```

prevents translations from being discarded when the source text changes. Existing translations are retained but marked for review, allowing translators to update capitalization or wording where appropriate.

This is preferable to automatically treating existing translations as valid because capitalization and wording rules can differ between languages.

#### Checklist

- [x] My pull request is properly named