### PR TITLE
fix: deeplink causing black screen on Ferdium

### DIFF
--- a/src/electron/deepLinking.ts
+++ b/src/electron/deepLinking.ts
@@ -1,22 +1,26 @@
 import type { BrowserWindow } from 'electron';
+
 import { protocolClient } from '../environment-remote';
+
+const protocolPrefix = `${protocolClient}://`;
+
+export function getDeepLinkFromArgs(args: string[]): string | undefined {
+  return args.find(arg => arg.startsWith(protocolPrefix));
+}
 
 export default function handleDeepLink(
   window: BrowserWindow,
   rawUrl: string,
 ): void {
-  if (!rawUrl) {
+  if (!rawUrl.startsWith(protocolPrefix)) {
     return;
   }
 
-  const url = rawUrl.replace(`${protocolClient}://`, '');
+  const url = rawUrl.slice(protocolPrefix.length);
 
-  // The next line is a workaround after this 71c5237 [chore: Mobx & React-Router upgrade (#406)].
-  // For some reason, the app won't start until because it's trying to route to './build'.
-  // TODO: Check what is wrong with DeepLinking - it is broken for some reason. This is causing several troubles.
-  const workaroundDeepLink = ['./build', '--allow-file-access-from-files'];
-
-  if (!url || workaroundDeepLink.includes(url)) return;
+  if (!url) {
+    return;
+  }
 
   window.webContents.send('navigateFromDeepLink', { url });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
 import { ifUndefined } from './jsUtils';
 
 import Settings from './electron/Settings';
-import handleDeepLink from './electron/deepLinking';
+import handleDeepLink, { getDeepLinkFromArgs } from './electron/deepLinking';
 import './electron/exception';
 // eslint-disable-next-line import/no-cycle
 import ipcApi from './electron/ipc-api';
@@ -136,8 +136,11 @@ if (gotTheLock) {
       if (isWindows) {
         onDidLoad((window: BrowserWindow) => {
           // Keep only command line / deep linked arguments
-          const url = argv.slice(1);
-          handleDeepLink(window, url.toString());
+          const deepLink = getDeepLinkFromArgs(argv);
+
+          if (deepLink) {
+            handleDeepLink(window, deepLink);
+          }
 
           if (argv.includes('--reset-window')) {
             // Needs to be delayed to not interfere with mainWindow.restore();
@@ -410,8 +413,11 @@ const createWindow = () => {
   // Windows deep linking handling on app launch
   if (isWindows) {
     onDidLoad((window: BrowserWindow) => {
-      const url = process.argv.slice(1);
-      handleDeepLink(window, url.toString());
+      const deepLink = getDeepLinkFromArgs(process.argv);
+
+      if (deepLink) {
+        handleDeepLink(window, deepLink);
+      }
     });
   }
 

--- a/test/deepLinking.test.ts
+++ b/test/deepLinking.test.ts
@@ -1,0 +1,66 @@
+import type * as DeepLinkingModule from '../src/electron/deepLinking';
+
+jest.mock('../src/environment-remote', () => ({
+  protocolClient: 'ferdium',
+}));
+
+const { default: handleDeepLink, getDeepLinkFromArgs } = jest.requireActual(
+  '../src/electron/deepLinking',
+) as typeof DeepLinkingModule;
+
+describe('deepLinking', () => {
+  describe('getDeepLinkFromArgs', () => {
+    it('ignores Chromium command-line switches', () => {
+      expect(
+        getDeepLinkFromArgs([
+          'Ferdium.exe',
+          '--allow-file-access-from-files',
+          '--source-app-id',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('extracts a Ferdium deep link among command-line switches', () => {
+      expect(
+        getDeepLinkFromArgs([
+          'Ferdium.exe',
+          '--allow-file-access-from-files',
+          'ferdium://service/123',
+          '--source-app-id',
+        ]),
+      ).toBe('ferdium://service/123');
+    });
+
+    it('ignores Ferdium task switches', () => {
+      expect(
+        getDeepLinkFromArgs([
+          'Ferdium.exe',
+          '--reset-window',
+          '--source-app-id',
+        ]),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('handleDeepLink', () => {
+    it('does not navigate for a non-Ferdium argument', () => {
+      const send = jest.fn();
+      const window = { webContents: { send } } as any;
+
+      handleDeepLink(window, '--allow-file-access-from-files,--source-app-id');
+
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('strips the protocol before navigating', () => {
+      const send = jest.fn();
+      const window = { webContents: { send } } as any;
+
+      handleDeepLink(window, 'ferdium://service/123');
+
+      expect(send).toHaveBeenCalledWith('navigateFromDeepLink', {
+        url: 'service/123',
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Fixes Windows deep-link handling so that only actual Ferdium protocol URLs are forwarded to the renderer.

Previously, Ferdium treated the remaining command-line arguments as a deep link by converting the `argv` array to a string. With additional Chromium/Electron arguments, this could produce values such as:

`--allow-file-access-from-files,--source-app-id`

This value was then forwarded to the renderer and passed to `history.push()`, causing an invalid route to be loaded and leaving Ferdium stuck on the initial blue screen.

This change:

- Extracts an actual `ferdium://` URL from the command-line arguments instead of treating all remaining arguments as a deep link.
- Ignores unrelated Electron/Chromium command-line arguments.
- Applies the same deep-link extraction when Ferdium is started normally and when a second instance is opened.
- Removes the need to maintain a list of individual command-line arguments that should be ignored.
- Keeps valid `ferdium://` deep links working as before.

#### Motivation and Context

Fixes #2489.

Ferdium 7.2.0 could fail to start on Windows because Electron/Chromium command-line arguments were being interpreted as application routes.

For example:

`--allow-file-access-from-files,--source-app-id`

was sent to the renderer as a deep link, resulting in errors such as:

`Relative pathnames are not supported in hash history.push(...)`

and:

`No routes matched location ...`

This is also the same general class of issue previously worked around in #444, where a non-deep-link startup argument (`./build`) was being interpreted as a route.

Rather than adding another Electron/Chromium argument to the existing workaround list, this change makes deep-link handling explicit: only arguments using Ferdium's registered protocol are considered deep links.

This should also prevent future Electron/Chromium command-line changes from causing similar routing regressions.

#### Screenshots

Not applicable.

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

notes: Fixed Ferdium getting stuck on the initial screen on Windows when Electron command-line arguments were incorrectly handled as deep links.