### PR TITLE
fix(arm): update electron-builder to fix #2491

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "concurrently": "8.2.2",
     "cross-env": "7.0.3",
     "electron": "43.3.0",
-    "electron-builder": "26.15.3",
+    "electron-builder": "26.15.7",
     "esbuild": "0.16.17",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-runner": "2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: 43.3.0
         version: 43.3.0(supports-color@5.5.0)
       electron-builder:
-        specifier: 26.15.3
-        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+        specifier: 26.15.7
+        version: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       esbuild:
         specifier: 0.16.17
         version: 0.16.17
@@ -2286,12 +2286,12 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  app-builder-lib@26.15.3:
-    resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
+  app-builder-lib@26.15.7:
+    resolution: {integrity: sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.15.3
-      electron-builder-squirrel-windows: 26.15.3
+      dmg-builder: 26.15.7
+      electron-builder-squirrel-windows: 26.15.7
 
   app-root-path@3.1.0:
     resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
@@ -3299,8 +3299,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dmg-builder@26.15.3:
-    resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
+  dmg-builder@26.15.7:
+    resolution: {integrity: sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3359,11 +3359,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.15.3:
-    resolution: {integrity: sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==}
+  electron-builder-squirrel-windows@26.15.7:
+    resolution: {integrity: sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==}
 
-  electron-builder@26.15.3:
-    resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
+  electron-builder@26.15.7:
+    resolution: {integrity: sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -10264,7 +10264,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0):
+  app-builder-lib@26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -10285,11 +10285,11 @@ snapshots:
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.3.7(supports-color@5.5.0)
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.9
-      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)(supports-color@5.5.0)
+      electron-builder-squirrel-windows: 26.15.7(dmg-builder@26.15.7)(supports-color@5.5.0)
       electron-publish: 26.15.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
@@ -11449,9 +11449,9 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0):
+  dmg-builder@26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       builder-util: 26.15.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       js-yaml: 4.1.0
@@ -11527,23 +11527,23 @@ snapshots:
     dependencies:
       jake: 10.8.7
 
-  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@5.5.0):
+  electron-builder-squirrel-windows@26.15.7(dmg-builder@26.15.7)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       builder-util: 26.15.3(supports-color@5.5.0)
       electron-winstaller: 5.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0):
+  electron-builder@26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       builder-util: 26.15.3(supports-color@5.5.0)
       builder-util-runtime: 9.7.0(supports-color@5.5.0)
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@5.5.0)
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -13417,7 +13417,7 @@ snapshots:
   is-weakset@2.0.2:
     dependencies:
       call-bind: 1.0.7
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
 
   is-windows@1.0.2: {}
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Updates `electron-builder` from `26.15.3` to `26.15.7`.

`electron-builder` 26.15.x introduced a regression affecting Windows NSIS and portable builds where the installer could complete successfully while failing to extract the main executable and other native binaries.

The issue is particularly visible on Windows ARM64, where affected Ferdium installations can be left without `Ferdium.exe`.

This PR updates `electron-builder` to a version containing the upstream fix and regenerates the lockfile accordingly.

#### Motivation and Context

Fixes #2491.

This appears to be caused by electron-userland/electron-builder#9983.

The regression was introduced by changes to the 7-Zip compression/filtering used for NSIS application packages. The NSIS extractor could fail to decode some executable/native binary streams and silently skip them during extraction.

The upstream fix was introduced in electron-userland/electron-builder#9988 and released in `electron-builder` 26.15.6. This PR updates to `26.15.7`, which includes that fix.

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally

#### Release Notes

Fix Windows NSIS and portable builds that could install without the Ferdium executable or other native binaries, particularly on ARM64.
