### PR TITLE
chore: migrate to core24 on snapcraft

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -312,8 +312,8 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }} # Note: Login no longer required https://forum.snapcraft.io/t/snapcraft-authentication-options/30473/21
         run: |
-          sudo snap install snapcraft --channel=7.x/stable --classic
-          pnpm build --publish always -c.snap.publish.repo=$SNAP_PUBLISH_REPO -c.snap.publish.channels=$SNAP_PUBLISH_CHANNEL
+          sudo snap install snapcraft --channel=8.x/stable --classic
+          pnpm build --publish always -c.snapcraft.publish.repo=$SNAP_PUBLISH_REPO -c.snapcraft.publish.channels=$SNAP_PUBLISH_CHANNEL
           snapcraft logout
         shell: bash
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -299,6 +299,15 @@ jobs:
         run: |
           pnpm lint
           pnpm test
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v1
+        with:
+          channel: latest/stable
+
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --channel=8.x/stable --classic
+
       - name: Build Ferdium without publish for any branch not 'nightly' and not 'release'
         if: ${{ env.GIT_BRANCH_NAME != 'nightly' && env.GIT_BRANCH_NAME != 'release' }}
         env:
@@ -312,7 +321,6 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }} # Note: Login no longer required https://forum.snapcraft.io/t/snapcraft-authentication-options/30473/21
         run: |
-          sudo snap install snapcraft --channel=8.x/stable --classic
           pnpm build --publish always -c.snapcraft.publish.repo=$SNAP_PUBLISH_REPO -c.snapcraft.publish.channels=$SNAP_PUBLISH_CHANNEL
           snapcraft logout
         shell: bash

--- a/build-helpers/snap-hooks/configure
+++ b/build-helpers/snap-hooks/configure
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-
-wayland_native="$(snapctl get wayland-native)"
-if [[ -z "$wayland_native" ]]; then
-    snapctl set wayland-native=true
-fi

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,9 +17,7 @@ snapcraft:
       - gnome
     plugs:
       - default
-      - browser-support:
-          interface: browser-support
-          allow-sandbox: true
+      - browser-support
       - camera
       - audio-record
       - removable-media

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,15 +7,23 @@ appId: "org.ferdium.ferdium-app"
 publish:
   provider: github
 
-snap:
-  base: core22
-  plugs: ["default", "camera", "audio-record", "removable-media"]
-  allowNativeWayland: true
-  executableArgs: ["$(sh -c '[ \"$(snapctl get wayland-native)\" = \"false\" ] && echo --ozone-platform=x11 || true')"]
-  hooks: ./build-helpers/snap-hooks
+snapcraft:
+  base: core24
   publish:
     provider: snapStore
-  description: 'Ferdium is your cross-platform messaging app / former heir to the throne of Austria-Hungary which brings your chat & messaging services together into one application. For enabling webcam access you need to connect "camera" plug to snap, and for microphone with PulseAudio the "audio-record" plug. This can be done in Snap GUI or via command: `snap connect ferdium:camera; snap connect ferdium:audio-record`.'
+  core24:
+    useLXD: true
+    extensions:
+      - gnome
+    plugs:
+      - default
+      - browser-support:
+          interface: browser-support
+          allow-sandbox: true
+      - camera
+      - audio-record
+      - removable-media
+    description: 'Ferdium is your cross-platform messaging app / former heir to the throne of Austria-Hungary which brings your chat & messaging services together into one application. For enabling webcam access you need to connect "camera" plug to snap, and for microphone with PulseAudio the "audio-record" plug. This can be done in Snap GUI or via command: `snap connect ferdium:camera; snap connect ferdium:audio-record`.'
 
 nsis:
   perMachine: false


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

## Description of Change

Migrates Ferdium's Snap packaging from the legacy `core22` configuration to the modern `core24` Snapcraft configuration supported by electron-builder.

This PR:

- Replaces the legacy `snap` electron-builder configuration with `snapcraft`.
- Changes the Snap base from `core22` to `core24`.
- Uses the `gnome` Snapcraft extension for the desktop and graphics runtime.
- Enables LXD-based Snapcraft builds with `useLXD`.
- Preserves Ferdium's existing custom Snap interfaces:
  - `camera`
  - `audio-record`
  - `removable-media`
- Explicitly configures `browser-support` with sandbox support enabled.
- Removes the legacy `wayland-native` configure hook and shell-based `--ozone-platform=x11` launcher logic.
- Updates CI from Snapcraft 7.x to Snapcraft 8.x.
- Updates the publish configuration path from `snap.*` to `snapcraft.*`.

No Ferdium application/runtime code or non-Snap packaging is changed by this PR.

## Motivation and Context

The existing Snap package uses electron-builder's legacy `core22` packaging path. With newer Electron/Chromium versions, this can result in the Snap graphics runtime failing to initialize EGL/OpenGL on some Linux environments, particularly virtualized systems.

A failing launch showed errors such as:

```text
MESA-LOADER: failed to open swrast
failed to load driver: swrast
Could not create a backing OpenGL context
EGL_NOT_INITIALIZED
Exiting GPU process due to errors during initialization
```

Forcing X11 alone did not resolve the issue:

```bash
snap run ferdium --ozone-platform=x11
```

However, bypassing the Snap-provided Mesa/OpenGL path with Chromium's SwiftShader renderer allowed Ferdium to start:

```bash
snap run ferdium \
  --ozone-platform=x11 \
  --use-gl=angle \
  --use-angle=swiftshader
```

This indicates that Ferdium itself and Electron are able to start, while the failure occurs in the legacy Snap graphics/runtime integration.

Rather than shipping `--disable-gpu` or SwiftShader as a permanent workaround, this PR moves Ferdium to the current `core24` Snapcraft implementation and GNOME extension, which provides the modern graphics runtime expected by current Electron releases.

The migration also removes the previous runtime Wayland/X11 shell workaround. Native Wayland/X11 handling should now be provided by the current Electron and Snapcraft runtime instead of being patched through the legacy Snap launcher.

Related upstream context: electron-userland/electron-builder#9452.

### Before

Launching the current `core22` Snap on the affected environment fails during GPU initialization and eventually terminates the Electron GPU process.

### After

The `core24` Snap launches normally without requiring:

```text
--disable-gpu
--use-gl=angle
--use-angle=swiftshader
--ozone-platform=x11
```

## Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

## Release Notes

Migrated the Linux Snap package from the legacy `core22` runtime to `core24`, improving compatibility with newer Electron/Chromium versions and modern Linux graphics environments.