### PR TITLE
fix: group enableSystemTray options

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.tsx
+++ b/src/components/settings/settings/EditSettingsForm.tsx
@@ -460,6 +460,14 @@ class EditSettingsForm extends Component<IProps, IState> {
           values.twoFactorAutoCatcherMatcher =
             DEFAULT_APP_SETTINGS.twoFactorAutoCatcherMatcher;
         }
+
+        if (!values.enableSystemTray) {
+          values.runInBackground = false;
+          values.startMinimized = false;
+          values.minimizeToSystemTray = false;
+          values.closeToSystemTray = false;
+        }
+
         this.props.onSubmit(values);
       },
       onError: noop,
@@ -511,6 +519,7 @@ class EditSettingsForm extends Component<IProps, IState> {
       reloadAfterResume,
       useSelfSignedCertificates,
       sandboxServices,
+      enableSystemTray,
     } = window['ferdium'].stores.settings.all.app;
 
     let cacheSize;
@@ -655,9 +664,7 @@ class EditSettingsForm extends Component<IProps, IState> {
                   {intl.formatMessage(messages.sectionMain)}
                 </H2>
                 <Toggle {...form.$('autoLaunchOnStart').bind()} />
-                <Toggle {...form.$('runInBackground').bind()} />
                 <Toggle {...form.$('confirmOnQuit').bind()} />
-                <Toggle {...form.$('enableSystemTray').bind()} />
                 {reloadAfterResume && <Hr />}
                 <Toggle {...form.$('reloadAfterResume').bind()} />
                 {reloadAfterResume && (
@@ -666,12 +673,21 @@ class EditSettingsForm extends Component<IProps, IState> {
                     <Hr />
                   </div>
                 )}
-                <Toggle {...form.$('startMinimized').bind()} />
-                {isWindows && (
-                  <Toggle {...form.$('minimizeToSystemTray').bind()} />
-                )}
-                {isWindows && (
-                  <Toggle {...form.$('closeToSystemTray').bind()} />
+
+                {enableSystemTray && <Hr />}
+                <Toggle {...form.$('enableSystemTray').bind()} />
+                {enableSystemTray && (
+                  <>
+                    <Toggle {...form.$('runInBackground').bind()} />
+                    <Toggle {...form.$('startMinimized').bind()} />
+                    {isWindows && (
+                      <Toggle {...form.$('minimizeToSystemTray').bind()} />
+                    )}
+                    {isWindows && (
+                      <Toggle {...form.$('closeToSystemTray').bind()} />
+                    )}
+                    <Hr />
+                  </>
                 )}
 
                 <Toggle {...form.$('keepAllWorkspacesLoaded').bind()} />

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -65,7 +65,7 @@ const messages = defineMessages({
   },
   enableSystemTray: {
     id: 'settings.app.form.enableSystemTray',
-    defaultMessage: 'Always show Ferdium in System Tray',
+    defaultMessage: 'Show Ferdium in System Tray',
   },
   enableMenuBar: {
     id: 'settings.app.form.enableMenuBar',
@@ -419,9 +419,12 @@ class EditSettingsScreen extends Component<
       lockedPassword: useOriginalPassword ? '' : settingsData.lockedPassword,
     });
 
+    const enableSystemTray = Boolean(settingsData.enableSystemTray);
+
     app.launchOnStartup({
       enable: Boolean(settingsData.autoLaunchOnStart),
-      openInBackground: Boolean(settingsData.autoLaunchInBackground),
+      openInBackground:
+        enableSystemTray && Boolean(settingsData.autoLaunchInBackground),
     });
 
     debug(`Updating settings store with data: ${settingsData}`);
@@ -429,14 +432,17 @@ class EditSettingsScreen extends Component<
     const { app: currentSettings } = this.props.stores.settings.all;
 
     const newSettings = {
-      runInBackground: Boolean(settingsData.runInBackground),
-      enableSystemTray: Boolean(settingsData.enableSystemTray),
+      runInBackground:
+        enableSystemTray && Boolean(settingsData.runInBackground),
+      enableSystemTray,
       reloadAfterResume: Boolean(settingsData.reloadAfterResume),
       reloadAfterResumeTime: Number(settingsData.reloadAfterResumeTime),
-      startMinimized: Boolean(settingsData.startMinimized),
+      startMinimized: enableSystemTray && Boolean(settingsData.startMinimized),
       confirmOnQuit: Boolean(settingsData.confirmOnQuit),
-      minimizeToSystemTray: Boolean(settingsData.minimizeToSystemTray),
-      closeToSystemTray: Boolean(settingsData.closeToSystemTray),
+      minimizeToSystemTray:
+        enableSystemTray && Boolean(settingsData.minimizeToSystemTray),
+      closeToSystemTray:
+        enableSystemTray && Boolean(settingsData.closeToSystemTray),
       privateNotifications: Boolean(settingsData.privateNotifications),
       clipboardNotifications: Boolean(settingsData.clipboardNotifications),
       notifyTaskBarOnMessage: Boolean(settingsData.notifyTaskBarOnMessage),
@@ -697,6 +703,10 @@ class EditSettingsScreen extends Component<
         globalMessages.spellcheckerAutomaticDetection,
       ),
     });
+    const isSystemTrayEnabled = ifUndefined<boolean>(
+      settings.all.app.enableSystemTray,
+      DEFAULT_APP_SETTINGS.enableSystemTray,
+    );
 
     const config: FormFields = {
       fields: {
@@ -720,20 +730,26 @@ class EditSettingsScreen extends Component<
         },
         runInBackground: {
           label: intl.formatMessage(messages.runInBackground),
-          value: ifUndefined<boolean>(
-            settings.all.app.runInBackground,
-            DEFAULT_APP_SETTINGS.runInBackground,
-          ),
+          value:
+            isSystemTrayEnabled &&
+            ifUndefined<boolean>(
+              settings.all.app.runInBackground,
+              DEFAULT_APP_SETTINGS.runInBackground,
+            ),
           default: DEFAULT_APP_SETTINGS.runInBackground,
+          disabled: !isSystemTrayEnabled,
           type: 'checkbox',
         },
         startMinimized: {
           label: intl.formatMessage(messages.startMinimized),
-          value: ifUndefined<boolean>(
-            settings.all.app.startMinimized,
-            DEFAULT_APP_SETTINGS.startMinimized,
-          ),
+          value:
+            isSystemTrayEnabled &&
+            ifUndefined<boolean>(
+              settings.all.app.startMinimized,
+              DEFAULT_APP_SETTINGS.startMinimized,
+            ),
           default: DEFAULT_APP_SETTINGS.startMinimized,
+          disabled: !isSystemTrayEnabled,
           type: 'checkbox',
         },
         confirmOnQuit: {
@@ -775,20 +791,26 @@ class EditSettingsScreen extends Component<
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
-          value: ifUndefined<boolean>(
-            settings.all.app.minimizeToSystemTray,
-            DEFAULT_APP_SETTINGS.minimizeToSystemTray,
-          ),
+          value:
+            isSystemTrayEnabled &&
+            ifUndefined<boolean>(
+              settings.all.app.minimizeToSystemTray,
+              DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+            ),
           default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+          disabled: !isSystemTrayEnabled,
           type: 'checkbox',
         },
         closeToSystemTray: {
           label: intl.formatMessage(messages.closeToSystemTray),
-          value: ifUndefined<boolean>(
-            settings.all.app.closeToSystemTray,
-            DEFAULT_APP_SETTINGS.closeToSystemTray,
-          ),
+          value:
+            isSystemTrayEnabled &&
+            ifUndefined<boolean>(
+              settings.all.app.closeToSystemTray,
+              DEFAULT_APP_SETTINGS.closeToSystemTray,
+            ),
           default: DEFAULT_APP_SETTINGS.closeToSystemTray,
+          disabled: !isSystemTrayEnabled,
           type: 'checkbox',
         },
         privateNotifications: {

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4102,7 +4102,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Always show Ferdium in System Tray",
+        "defaultMessage": "!!!Show Ferdium in System Tray",
         "end": {
           "column": 3,
           "line": 49

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -278,7 +278,7 @@
   "settings.app.form.enableLongPressServiceHint": "Enable service shortcut hint on long press",
   "settings.app.form.enableMenuBar": "Always show Ferdium in Menu Bar",
   "settings.app.form.enableSpellchecking": "Enable spell checking",
-  "settings.app.form.enableSystemTray": "Always show Ferdium in System Tray",
+  "settings.app.form.enableSystemTray": "Show Ferdium in System Tray",
   "settings.app.form.enableTodos": "Enable Ferdium Todos",
   "settings.app.form.enableTranslator": "Enable Translator",
   "settings.app.form.grayscaleServicesDim": "Grayscale dim level",

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,40 @@ const shortcutSettings = new Settings('shortcuts', DEFAULT_SHORTCUTS);
 const retrieveSettingValue = (key: string, defaultValue: boolean | string) =>
   ifUndefined<boolean | string>(settings.get(key), defaultValue);
 
+const normalizeAppSettings = (): void => {
+  if (settings.get('enableSystemTray') !== false) {
+    return;
+  }
+
+  const normalizedSettings: Partial<typeof DEFAULT_APP_SETTINGS> = {};
+
+  if (settings.get('runInBackground') !== false) {
+    normalizedSettings.runInBackground = false;
+  }
+
+  if (settings.get('startMinimized') !== false) {
+    normalizedSettings.startMinimized = false;
+  }
+
+  if (settings.get('minimizeToSystemTray') !== false) {
+    normalizedSettings.minimizeToSystemTray = false;
+  }
+
+  if (settings.get('closeToSystemTray') !== false) {
+    normalizedSettings.closeToSystemTray = false;
+  }
+
+  if (Object.keys(normalizedSettings).length > 0) {
+    debug(
+      'Normalizing app settings for disabled system tray',
+      normalizedSettings,
+    );
+    settings.set(normalizedSettings);
+  }
+};
+
+normalizeAppSettings();
+
 // TODO: Commenting out sentry to fix https://github.com/ferdium/ferdium-app/issues/814
 // if (retrieveSettingValue('sentry', DEFAULT_APP_SETTINGS.sentry)) {
 //   // eslint-disable-next-line global-require


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Groups settings that depend on the system tray under the **Show Ferdium in System Tray** option and prevents contradictory configurations when the system tray is disabled.

This change:

- Treats `enableSystemTray` as the parent setting for:
  - `runInBackground`
  - `startMinimized`
  - `minimizeToSystemTray` on Windows
  - `closeToSystemTray` on Windows
- Only displays the dependent settings when the system tray is enabled.
- Forces those settings to `false` when the system tray is disabled.
- Normalizes existing configurations at startup where the system tray is disabled but dependent options are still enabled.
- Prevents auto-launch from opening Ferdium in the background when the system tray is disabled.
- Updates the setting label from **Always show Ferdium in System Tray** to **Show Ferdium in System Tray**.

#### Motivation and Context

Follow-up to #2489 and #2494.

While investigating #2489, two separate startup problems became apparent.

The blue-screen issue caused by Electron/Chromium command-line arguments being interpreted as deep links was addressed by #2494.

The investigation also highlighted an inconsistent settings state: options such as **Start minimized** or **Run in background** could remain enabled while the system tray itself was disabled.

This can make Ferdium appear not to start because the first instance is running with its window hidden and there is no system tray icon available to restore it. Starting Ferdium again then activates the already-running instance, resulting in behavior similar to the "two clicks to initiate Ferdium" symptom reported in #2489.

These options only make sense when a system tray is available, so this change makes their dependency explicit in both the settings UI and persisted application state.

It also cleans up existing inconsistent configurations automatically so users do not need to manually reset their settings.

#### Screenshots

<!-- Add a screenshot of the System Tray setting with the dependent options expanded/collapsed if desired. -->

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

notes: Fixed inconsistent system tray settings that could cause Ferdium to start or remain hidden when the system tray is disabled.