### PR TITLE
fix: pin Electron to 42.9.3 to fix Linux tray icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "chalk": "5.3.0",
     "concurrently": "8.2.2",
     "cross-env": "7.0.3",
-    "electron": "43.3.0",
+    "electron": "42.9.3",
     "electron-builder": "26.15.7",
     "esbuild": "0.16.17",
     "esbuild-plugin-copy": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 5.1.0
       '@electron/remote':
         specifier: 2.1.2
-        version: 2.1.2(electron@43.3.0(supports-color@5.5.0))
+        version: 2.1.2(electron@42.9.3(supports-color@5.5.0))
       '@emotion/react':
         specifier: 11.13.3
         version: 11.13.3(@types/react@18.3.12)(react@18.3.1)
@@ -73,7 +73,7 @@ importers:
         version: 7.4.0(history@5.3.0)(mobx@6.13.5)(path-to-regexp@6.2.2)
       '@syed_umair/electron-process-manager':
         specifier: 1.1.0
-        version: 1.1.0(electron@43.3.0(supports-color@5.5.0))
+        version: 1.1.0(electron@42.9.3(supports-color@5.5.0))
       auto-launch:
         specifier: 5.0.6
         version: 5.0.6
@@ -109,7 +109,7 @@ importers:
         version: 6.3.9(supports-color@5.5.0)
       electron-webauthn-linux:
         specifier: 0.1.1
-        version: 0.1.1(electron@43.3.0(supports-color@5.5.0))
+        version: 0.1.1(electron@42.9.3(supports-color@5.5.0))
       electron-window-state:
         specifier: 5.0.3
         version: 5.0.3
@@ -355,8 +355,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       electron:
-        specifier: 43.3.0
-        version: 43.3.0(supports-color@5.5.0)
+        specifier: 42.9.3
+        version: 42.9.3(supports-color@5.5.0)
       electron-builder:
         specifier: 26.15.7
         version: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@5.5.0)
@@ -3403,8 +3403,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.3.0:
-    resolution: {integrity: sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==}
+  electron@42.9.3:
+    resolution: {integrity: sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -8532,9 +8532,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/remote@2.1.2(electron@43.3.0(supports-color@5.5.0))':
+  '@electron/remote@2.1.2(electron@42.9.3(supports-color@5.5.0))':
     dependencies:
-      electron: 43.3.0(supports-color@5.5.0)
+      electron: 42.9.3(supports-color@5.5.0)
 
   '@electron/universal@2.0.3(supports-color@5.5.0)':
     dependencies:
@@ -9558,9 +9558,9 @@ snapshots:
       mobx: 6.13.5
       path-to-regexp: 6.2.2
 
-  '@syed_umair/electron-process-manager@1.1.0(electron@43.3.0(supports-color@5.5.0))':
+  '@syed_umair/electron-process-manager@1.1.0(electron@42.9.3(supports-color@5.5.0))':
     dependencies:
-      electron: 43.3.0(supports-color@5.5.0)
+      electron: 42.9.3(supports-color@5.5.0)
       electron-process-reporter: 1.4.0
 
   '@szmarczak/http-timer@4.0.6':
@@ -11605,9 +11605,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-webauthn-linux@0.1.1(electron@43.3.0(supports-color@5.5.0)):
+  electron-webauthn-linux@0.1.1(electron@42.9.3(supports-color@5.5.0)):
     dependencies:
-      electron: 43.3.0(supports-color@5.5.0)
+      electron: 42.9.3(supports-color@5.5.0)
 
   electron-window-state@5.0.3:
     dependencies:
@@ -11626,7 +11626,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.3.0(supports-color@5.5.0):
+  electron@42.9.3(supports-color@5.5.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@5.5.0)


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Pins Electron 43.3.0 back to 42.9.3. One line in `package.json` plus the regenerated lockfile (electron-only diff, no transitive churn: 42.9.3 resolves to the same deps as 43.3.0). 42.9.3 is still inside Electron's supported window.

#### Motivation and Context

Fixes https://github.com/ferdium/ferdium-app/issues/2493, the broken Linux tray icon in 7.2.0 and 7.2.1.

In Electron 43 the StatusNotifierItem answers D-Bus `Properties.Get` only when addressed to its well-known name; the same call to the connection's unique name is refused with `error occurred in Get`. Tray hosts resolve to the unique name before querying, so every property read fails. Hence GNOME destroys the item, Cinnamon shows a dead placeholder, KDE shows nothing.

Repros with a 15-line Electron app that only calls `new Tray(...)`:

| Electron | result |
|---|---|
| 42.9.3 | ✅ icon appears and stays |
| 43.3.0 | ❌ appears, then vanishes |
| 43.4.1 | ❌ never appears (malformed registration argument) |
| 45.0.0-nightly.20260819 | ❌ placeholder icon, clicks dead |

Also A/B'd against the released 7.2.1 package with stock `app.asar`, swapping only the runtime: broken on 43.3.0, `Get(Id)` 15/15 and tray fully working on 42.9.3. So nothing in the current source needs an Electron 43 API.

Upstream ([electron#52674](https://github.com/electron/electron/issues/52674)) is still `blocked/upstream`; the Chromium fix hasn't shipped in any Electron release.

Tested on Fedora 44, GNOME 50.4, Wayland. #2493 confirms the same breakage and the same electron42 fix on Cinnamon and KDE.

#### Checklist

- [x] My pull request is properly named
- [ ] The changes respect the code style of the project (`pnpm prepare-code`), not run locally as no source files changed
- [ ] `pnpm test` passes, not run locally as no source files changed
- [x] I tested/previewed my changes locally

#### Release Notes

Fix the Linux system tray icon by pinning Electron to 42.9.3, working around an Electron 43 D-Bus regression.