### PR TITLE
fix: bypass Electron tray on Linux with StatusNotifierItem

### DIFF
--- a/src/lib/DBus.ts
+++ b/src/lib/DBus.ts
@@ -6,6 +6,11 @@ import { isLinux } from '../environment';
 import type TrayIcon from './Tray';
 import Ferdium, { type UnreadServices } from './dbus/Ferdium';
 
+const STATUS_NOTIFIER_WATCHERS = new Set([
+  'org.kde.StatusNotifierWatcher',
+  'org.freedesktop.StatusNotifierWatcher',
+]);
+
 export default class DBus {
   private bus: MessageBus | null = null;
 
@@ -87,7 +92,9 @@ export default class DBus {
     this.ferdium = new Ferdium(this);
     this.bus.export('/org/ferdium', this.ferdium);
 
-    // HACK Hook onto the MessageBus to track StatusNotifierWatchers
+    // Track StatusNotifierWatcher restarts. The custom Linux tray keeps its
+    // own D-Bus connection, so after a watcher restart it only needs to
+    // re-register its StatusNotifierItem and re-announce the icon.
     // @ts-expect-error Property '_addMatch' does not exist on type 'MessageBus'.
     this.bus._addMatch(
       "type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',path='/org/freedesktop/DBus',member='NameOwnerChanged'",
@@ -101,7 +108,7 @@ export default class DBus {
     this.bus._signals.on(mangled, (msg: { body: [any, any, any] }) => {
       const [name, oldOwner, newOwner] = msg.body;
       if (
-        name === 'org.kde.StatusNotifierWatcher' &&
+        STATUS_NOTIFIER_WATCHERS.has(name) &&
         oldOwner !== newOwner &&
         newOwner !== ''
       ) {

--- a/src/lib/LinuxTray.ts
+++ b/src/lib/LinuxTray.ts
@@ -5,9 +5,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { type NativeImage, nativeImage } from 'electron';
 import * as dbus from 'dbus-next';
 import type { MessageBus } from 'dbus-next';
+import { type NativeImage, nativeImage } from 'electron';
 
 const STATUS_NOTIFIER_ITEM_PATH = '/StatusNotifierItem';
 const DBUS_MENU_PATH = '/Menu';
@@ -576,7 +576,7 @@ export default class LinuxTray {
     const nextIconPath = join(nextDirectory, `${nextIconName}.png`);
 
     try {
-      writeFileSync(nextIconPath, image.toPNG());
+      writeFileSync(nextIconPath, Uint8Array.from(image.toPNG()));
     } catch (error) {
       rmSync(nextDirectory, { recursive: true, force: true });
       throw error;

--- a/src/lib/LinuxTray.ts
+++ b/src/lib/LinuxTray.ts
@@ -1,0 +1,669 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/class-literal-property-style */
+/* eslint-disable max-classes-per-file */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { type NativeImage, nativeImage } from 'electron';
+import * as dbus from 'dbus-next';
+import type { MessageBus } from 'dbus-next';
+
+const STATUS_NOTIFIER_ITEM_PATH = '/StatusNotifierItem';
+const DBUS_MENU_PATH = '/Menu';
+const STATUS_NOTIFIER_ITEM_INTERFACES = [
+  'org.kde.StatusNotifierItem',
+  'org.freedesktop.StatusNotifierItem',
+];
+const STATUS_NOTIFIER_WATCHERS = [
+  {
+    service: 'org.kde.StatusNotifierWatcher',
+    interface: 'org.kde.StatusNotifierWatcher',
+  },
+  {
+    service: 'org.freedesktop.StatusNotifierWatcher',
+    interface: 'org.freedesktop.StatusNotifierWatcher',
+  },
+];
+
+const { ACCESS_READ } = dbus.interface;
+
+export interface LinuxTrayMenuItem {
+  label: string;
+  click: () => void;
+}
+
+interface LinuxTrayOptions {
+  onActivate: () => void;
+  onContextMenu?: () => void;
+}
+
+type MenuProperties = Record<string, dbus.Variant>;
+type MenuLayout = [number, MenuProperties, dbus.Variant[]];
+type StatusNotifierPixmap = [number, number, Buffer][];
+
+interface StatusNotifierOwner {
+  readonly iconName: string;
+  readonly iconThemePath: string;
+  readonly iconPixmap: StatusNotifierPixmap;
+  activate: () => void;
+  showFallbackContextMenu: () => void;
+}
+
+let nativeBitmapFormat: 'rgba' | 'bgra' | null = null;
+
+function getNativeBitmapFormat(): 'rgba' | 'bgra' {
+  if (nativeBitmapFormat) {
+    return nativeBitmapFormat;
+  }
+
+  // NativeImage.toBitmap() is explicitly platform-dependent. Linux Electron
+  // uses RGBA/BGRA layouts depending on the underlying representation, so
+  // detect the ordering with a known opaque red pixel before converting the
+  // Ferdium icon to the ARGB network-byte-order expected by StatusNotifierItem.
+  const redPixel = nativeImage.createFromDataURL(
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  );
+  const bitmap = redPixel.toBitmap();
+  nativeBitmapFormat = bitmap[0] > bitmap[2] ? 'rgba' : 'bgra';
+  return nativeBitmapFormat;
+}
+
+function makeStatusNotifierPixmap(image: NativeImage): StatusNotifierPixmap {
+  const { width, height } = image.getSize();
+  if (width <= 0 || height <= 0) {
+    return [];
+  }
+
+  const bitmap = image.toBitmap();
+  const expectedLength = width * height * 4;
+  if (bitmap.length < expectedLength) {
+    return [];
+  }
+
+  const format = getNativeBitmapFormat();
+  const argb = Buffer.alloc(expectedLength);
+  for (let offset = 0; offset < expectedLength; offset += 4) {
+    const redOffset = format === 'rgba' ? offset : offset + 2;
+    const blueOffset = format === 'rgba' ? offset + 2 : offset;
+    argb[offset] = bitmap[offset + 3];
+    argb[offset + 1] = bitmap[redOffset];
+    argb[offset + 2] = bitmap[offset + 1];
+    argb[offset + 3] = bitmap[blueOffset];
+  }
+
+  return [[width, height, argb]];
+}
+
+class StatusNotifierItem extends dbus.interface.Interface {
+  constructor(
+    private readonly owner: StatusNotifierOwner,
+    interfaceName: string,
+  ) {
+    super(interfaceName);
+  }
+
+  get Category(): string {
+    return 'Communications';
+  }
+
+  get Id(): string {
+    return 'ferdium';
+  }
+
+  get Title(): string {
+    return 'Ferdium';
+  }
+
+  get Status(): string {
+    return 'Active';
+  }
+
+  get WindowId(): number {
+    return 0;
+  }
+
+  get IconName(): string {
+    return this.owner.iconName;
+  }
+
+  get IconThemePath(): string {
+    return this.owner.iconThemePath;
+  }
+
+  get IconPixmap(): StatusNotifierPixmap {
+    return this.owner.iconPixmap;
+  }
+
+  get OverlayIconName(): string {
+    return '';
+  }
+
+  get OverlayIconPixmap(): unknown[] {
+    return [];
+  }
+
+  get AttentionIconName(): string {
+    return '';
+  }
+
+  get AttentionIconPixmap(): unknown[] {
+    return [];
+  }
+
+  get AttentionMovieName(): string {
+    return '';
+  }
+
+  get ToolTip(): [string, unknown[], string, string] {
+    return ['', [], 'Ferdium', ''];
+  }
+
+  get ItemIsMenu(): boolean {
+    return false;
+  }
+
+  get Menu(): string {
+    return DBUS_MENU_PATH;
+  }
+
+  ContextMenu(_x: number, _y: number): void {
+    this.owner.showFallbackContextMenu();
+  }
+
+  Activate(_x: number, _y: number): void {
+    this.owner.activate();
+  }
+
+  SecondaryActivate(_x: number, _y: number): void {
+    this.owner.activate();
+  }
+
+  Scroll(_delta: number, _orientation: string): void {
+    // Ferdium does not attach any behavior to tray scroll events.
+  }
+
+  NewTitle(): void {
+    // The signal has no payload.
+  }
+
+  NewIcon(): void {
+    // The signal has no payload.
+  }
+
+  NewIconThemePath(_path: string): string {
+    return _path;
+  }
+
+  NewAttentionIcon(): void {
+    // The signal has no payload.
+  }
+
+  NewOverlayIcon(): void {
+    // The signal has no payload.
+  }
+
+  NewToolTip(): void {
+    // The signal has no payload.
+  }
+
+  NewStatus(status: string): string {
+    return status;
+  }
+}
+
+StatusNotifierItem.configureMembers({
+  methods: {
+    ContextMenu: { inSignature: 'ii', outSignature: '' },
+    Activate: { inSignature: 'ii', outSignature: '' },
+    SecondaryActivate: { inSignature: 'ii', outSignature: '' },
+    Scroll: { inSignature: 'is', outSignature: '' },
+  },
+  properties: {
+    Category: { signature: 's', access: ACCESS_READ },
+    Id: { signature: 's', access: ACCESS_READ },
+    Title: { signature: 's', access: ACCESS_READ },
+    Status: { signature: 's', access: ACCESS_READ },
+    WindowId: { signature: 'i', access: ACCESS_READ },
+    IconName: { signature: 's', access: ACCESS_READ },
+    IconThemePath: { signature: 's', access: ACCESS_READ },
+    IconPixmap: { signature: 'a(iiay)', access: ACCESS_READ },
+    OverlayIconName: { signature: 's', access: ACCESS_READ },
+    OverlayIconPixmap: { signature: 'a(iiay)', access: ACCESS_READ },
+    AttentionIconName: { signature: 's', access: ACCESS_READ },
+    AttentionIconPixmap: { signature: 'a(iiay)', access: ACCESS_READ },
+    AttentionMovieName: { signature: 's', access: ACCESS_READ },
+    ToolTip: { signature: '(sa(iiay)ss)', access: ACCESS_READ },
+    ItemIsMenu: { signature: 'b', access: ACCESS_READ },
+    Menu: { signature: 'o', access: ACCESS_READ },
+  },
+  signals: {
+    NewTitle: { signature: '' },
+    NewIcon: { signature: '' },
+    NewIconThemePath: { signature: 's' },
+    NewAttentionIcon: { signature: '' },
+    NewOverlayIcon: { signature: '' },
+    NewToolTip: { signature: '' },
+    NewStatus: { signature: 's' },
+  },
+});
+
+class DBusMenu extends dbus.interface.Interface {
+  private items: LinuxTrayMenuItem[] = [];
+
+  private revision = 1;
+
+  constructor() {
+    super('com.canonical.dbusmenu');
+  }
+
+  get Version(): number {
+    return 3;
+  }
+
+  get TextDirection(): string {
+    return 'ltr';
+  }
+
+  get Status(): string {
+    return 'normal';
+  }
+
+  get IconThemePath(): string[] {
+    return [];
+  }
+
+  setItems(items: LinuxTrayMenuItem[], emitSignal: boolean): void {
+    this.items = items;
+    this.revision += 1;
+    if (emitSignal) {
+      this.LayoutUpdated(this.revision, 0);
+    }
+  }
+
+  private itemIds(): number[] {
+    return this.items.map((_, index) => index + 1);
+  }
+
+  private getItem(id: number): LinuxTrayMenuItem | undefined {
+    if (id <= 0) {
+      return undefined;
+    }
+    return this.items[id - 1];
+  }
+
+  private propertiesFor(id: number, propertyNames: string[]): MenuProperties {
+    const available: MenuProperties = {};
+
+    if (id === 0) {
+      if (this.items.length > 0) {
+        available['children-display'] = new dbus.Variant('s', 'submenu');
+      }
+    } else {
+      const item = this.getItem(id);
+      if (!item) {
+        return {};
+      }
+      available.label = new dbus.Variant('s', item.label);
+    }
+
+    if (propertyNames.length === 0) {
+      return available;
+    }
+
+    const filtered: MenuProperties = {};
+    for (const propertyName of propertyNames) {
+      if (available[propertyName]) {
+        filtered[propertyName] = available[propertyName];
+      }
+    }
+    return filtered;
+  }
+
+  private layoutFor(
+    id: number,
+    recursionDepth: number,
+    propertyNames: string[],
+  ): MenuLayout {
+    let children: dbus.Variant[] = [];
+
+    if (id === 0 && recursionDepth !== 0) {
+      const nextDepth =
+        recursionDepth > 0 ? recursionDepth - 1 : recursionDepth;
+      children = this.itemIds().map(
+        childId =>
+          new dbus.Variant(
+            '(ia{sv}av)',
+            this.layoutFor(childId, nextDepth, propertyNames),
+          ),
+      );
+    }
+
+    return [id, this.propertiesFor(id, propertyNames), children];
+  }
+
+  GetLayout(
+    parentId: number,
+    recursionDepth: number,
+    propertyNames: string[],
+  ): [number, MenuLayout] {
+    return [
+      this.revision,
+      this.layoutFor(parentId, recursionDepth, propertyNames),
+    ];
+  }
+
+  GetGroupProperties(
+    ids: number[],
+    propertyNames: string[],
+  ): [number, MenuProperties][] {
+    const requestedIds = ids.length > 0 ? ids : [0, ...this.itemIds()];
+    return requestedIds.map(id => [id, this.propertiesFor(id, propertyNames)]);
+  }
+
+  GetProperty(id: number, name: string): dbus.Variant {
+    const property = this.propertiesFor(id, [name])[name];
+    if (!property) {
+      throw new dbus.DBusError(
+        'com.canonical.dbusmenu.Error.UnknownProperty',
+        `Unknown menu property ${name} for item ${id}`,
+      );
+    }
+    return property;
+  }
+
+  Event(
+    id: number,
+    eventId: string,
+    _data: dbus.Variant,
+    _timestamp: number,
+  ): void {
+    if (eventId !== 'clicked') {
+      return;
+    }
+    this.getItem(id)?.click();
+  }
+
+  EventGroup(events: [number, string, dbus.Variant, number][]): number[] {
+    const errors: number[] = [];
+
+    for (const [id, eventId] of events) {
+      const item = this.getItem(id);
+      if (!item) {
+        errors.push(id);
+      } else if (eventId === 'clicked') {
+        item.click();
+      }
+    }
+
+    return errors;
+  }
+
+  AboutToShow(_id: number): boolean {
+    return false;
+  }
+
+  AboutToShowGroup(ids: number[]): [number[], number[]] {
+    const errors = ids.filter(id => id !== 0 && !this.getItem(id));
+    return [[], errors];
+  }
+
+  LayoutUpdated(revision: number, parent: number): [number, number] {
+    return [revision, parent];
+  }
+
+  ItemsPropertiesUpdated(
+    updatedProps: [number, MenuProperties][],
+    removedProps: [number, string[]][],
+  ): [[number, MenuProperties][], [number, string[]][]] {
+    return [updatedProps, removedProps];
+  }
+
+  ItemActivationRequested(id: number, timestamp: number): [number, number] {
+    return [id, timestamp];
+  }
+}
+
+DBusMenu.configureMembers({
+  methods: {
+    GetLayout: {
+      inSignature: 'iias',
+      outSignature: 'u(ia{sv}av)',
+    },
+    GetGroupProperties: {
+      inSignature: 'aias',
+      outSignature: 'a(ia{sv})',
+    },
+    GetProperty: {
+      inSignature: 'is',
+      outSignature: 'v',
+    },
+    Event: {
+      inSignature: 'isvu',
+      outSignature: '',
+    },
+    EventGroup: {
+      inSignature: 'a(isvu)',
+      outSignature: 'ai',
+    },
+    AboutToShow: {
+      inSignature: 'i',
+      outSignature: 'b',
+    },
+    AboutToShowGroup: {
+      inSignature: 'ai',
+      outSignature: 'aiai',
+    },
+  },
+  properties: {
+    Version: { signature: 'u', access: ACCESS_READ },
+    TextDirection: { signature: 's', access: ACCESS_READ },
+    Status: { signature: 's', access: ACCESS_READ },
+    IconThemePath: { signature: 'as', access: ACCESS_READ },
+  },
+  signals: {
+    LayoutUpdated: { signature: 'ui' },
+    ItemsPropertiesUpdated: { signature: 'a(ia{sv})a(ias)' },
+    ItemActivationRequested: { signature: 'iu' },
+  },
+});
+
+export default class LinuxTray {
+  private bus: MessageBus | null = null;
+
+  private readonly statusNotifierItems: StatusNotifierItem[];
+
+  private readonly menu = new DBusMenu();
+
+  private readonly serviceName = `org.freedesktop.StatusNotifierItem-${process.pid}-1`;
+
+  private iconDirectory: string | null = null;
+
+  private currentIconName = '';
+
+  private currentIconPixmap: StatusNotifierPixmap = [];
+
+  private iconRevision = 0;
+
+  private active = false;
+
+  private exported = false;
+
+  private startPromise: Promise<void> | null = null;
+
+  constructor(private readonly options: LinuxTrayOptions) {
+    this.statusNotifierItems = STATUS_NOTIFIER_ITEM_INTERFACES.map(
+      interfaceName => new StatusNotifierItem(this, interfaceName),
+    );
+  }
+
+  get iconName(): string {
+    return this.currentIconName;
+  }
+
+  get iconThemePath(): string {
+    return this.iconDirectory ?? '';
+  }
+
+  get iconPixmap(): StatusNotifierPixmap {
+    return this.currentIconPixmap;
+  }
+
+  async show(
+    image: NativeImage,
+    menuItems: LinuxTrayMenuItem[],
+  ): Promise<void> {
+    this.active = true;
+    this.menu.setItems(menuItems, false);
+    this.setImage(image);
+
+    if (this.bus) {
+      await this.registerWithWatcher();
+      return;
+    }
+
+    if (!this.startPromise) {
+      this.startPromise = this.start();
+    }
+
+    try {
+      await this.startPromise;
+    } finally {
+      this.startPromise = null;
+    }
+  }
+
+  private async start(): Promise<void> {
+    const bus = dbus.sessionBus();
+    this.bus = bus;
+
+    try {
+      await bus.requestName(this.serviceName, 0);
+
+      if (!this.active || this.bus !== bus) {
+        return;
+      }
+
+      bus.export(DBUS_MENU_PATH, this.menu);
+      for (const statusNotifierItem of this.statusNotifierItems) {
+        bus.export(STATUS_NOTIFIER_ITEM_PATH, statusNotifierItem);
+      }
+      this.exported = true;
+
+      await this.registerWithWatcher();
+    } catch (error) {
+      if (this.bus === bus) {
+        this.bus = null;
+        this.exported = false;
+      }
+      bus.disconnect();
+      throw error;
+    }
+  }
+
+  setMenu(menuItems: LinuxTrayMenuItem[]): void {
+    this.menu.setItems(menuItems, this.exported);
+  }
+
+  setImage(image: NativeImage): void {
+    if (!this.active) {
+      return;
+    }
+
+    const nextDirectory = mkdtempSync(join(tmpdir(), 'ferdium-tray-'));
+    this.iconRevision += 1;
+    const nextIconName = `ferdium-tray-${this.iconRevision}`;
+    const nextIconPath = join(nextDirectory, `${nextIconName}.png`);
+
+    try {
+      writeFileSync(nextIconPath, image.toPNG());
+    } catch (error) {
+      rmSync(nextDirectory, { recursive: true, force: true });
+      throw error;
+    }
+
+    const previousDirectory = this.iconDirectory;
+    this.iconDirectory = nextDirectory;
+    this.currentIconName = nextIconName;
+    this.currentIconPixmap = makeStatusNotifierPixmap(image);
+
+    if (this.exported) {
+      for (const statusNotifierItem of this.statusNotifierItems) {
+        statusNotifierItem.NewIconThemePath(nextDirectory);
+        statusNotifierItem.NewIcon();
+      }
+    }
+
+    if (previousDirectory) {
+      rmSync(previousDirectory, { recursive: true, force: true });
+    }
+  }
+
+  activate(): void {
+    this.options.onActivate();
+  }
+
+  showFallbackContextMenu(): void {
+    this.options.onContextMenu?.();
+  }
+
+  async refreshAfterWatcherRestart(): Promise<void> {
+    if (!this.active || !this.bus) {
+      return;
+    }
+
+    await this.registerWithWatcher();
+    for (const statusNotifierItem of this.statusNotifierItems) {
+      statusNotifierItem.NewIconThemePath(this.iconThemePath);
+      statusNotifierItem.NewIcon();
+    }
+  }
+
+  private async registerWithWatcher(): Promise<boolean> {
+    if (!this.active || !this.bus) {
+      return false;
+    }
+
+    const tryRegister = async (
+      watcher: (typeof STATUS_NOTIFIER_WATCHERS)[number],
+    ): Promise<boolean> => {
+      if (!this.bus) {
+        return false;
+      }
+      try {
+        const proxyObject = await this.bus.getProxyObject(
+          watcher.service,
+          '/StatusNotifierWatcher',
+        );
+        const watcherInterface = proxyObject.getInterface(watcher.interface);
+        await watcherInterface.RegisterStatusNotifierItem(this.serviceName);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const [legacyWatcher, currentWatcher] = STATUS_NOTIFIER_WATCHERS;
+    if (await tryRegister(legacyWatcher)) {
+      return true;
+    }
+    return tryRegister(currentWatcher);
+  }
+
+  destroy(): void {
+    this.active = false;
+    this.exported = false;
+
+    if (this.bus) {
+      this.bus.disconnect();
+      this.bus = null;
+    }
+
+    if (this.iconDirectory) {
+      rmSync(this.iconDirectory, { recursive: true, force: true });
+      this.iconDirectory = null;
+      this.currentIconName = '';
+      this.currentIconPixmap = [];
+    }
+  }
+}

--- a/src/lib/Tray.ts
+++ b/src/lib/Tray.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+
 import {
   BrowserWindow,
   Menu,
@@ -11,8 +12,10 @@ import {
   systemPreferences,
 } from 'electron';
 import macosVersion from 'macos-version';
+
 import { isLinux, isMac, isWindows } from '../environment';
 import { getTranslatedText } from '../helpers/i18n-helpers';
+import LinuxTray, { type LinuxTrayMenuItem } from './LinuxTray';
 
 const FILE_EXTENSION = isWindows ? 'ico' : 'png';
 const INDICATOR_TRAY_PLAIN = 'tray';
@@ -21,6 +24,8 @@ const INDICATOR_TRAY_INDIRECT = 'tray-indirect';
 
 export default class TrayIcon {
   tray: Tray | null = null;
+
+  linuxTray: LinuxTray | null = null;
 
   indicator: string | number = 0;
 
@@ -69,7 +74,7 @@ export default class TrayIcon {
     });
   }
 
-  trayMenuTemplate(tray) {
+  trayMenuTemplate(tray): LinuxTrayMenuItem[] {
     return [
       {
         label:
@@ -119,7 +124,7 @@ export default class TrayIcon {
   }
 
   _updateTrayMenu(appSettings): void {
-    if (!this.tray) {
+    if (!this.tray && !this.linuxTray) {
       return;
     }
 
@@ -130,9 +135,11 @@ export default class TrayIcon {
       }
     }
 
-    this.trayMenu = Menu.buildFromTemplate(this.trayMenuTemplate(this));
+    const menuTemplate = this.trayMenuTemplate(this);
+    this.trayMenu = Menu.buildFromTemplate(menuTemplate);
+
     if (isLinux) {
-      this.tray.setContextMenu(this.trayMenu);
+      this.linuxTray?.setMenu(menuTemplate);
     }
   }
 
@@ -142,6 +149,37 @@ export default class TrayIcon {
   }
 
   _show(): void {
+    if (isLinux) {
+      if (this.linuxTray) {
+        return;
+      }
+
+      const menuTemplate = this.trayMenuTemplate(this);
+      this.trayMenu = Menu.buildFromTemplate(menuTemplate);
+
+      const linuxTray = new LinuxTray({
+        onActivate: () => {
+          this._toggleWindow();
+        },
+        onContextMenu: () => {
+          if (this.trayMenu && this.mainWindow) {
+            this.trayMenu.popup({ window: this.mainWindow });
+          }
+        },
+      });
+      this.linuxTray = linuxTray;
+
+      linuxTray
+        .show(this._getAsset('tray', INDICATOR_TRAY_PLAIN), menuTemplate)
+        .catch(() => {
+          if (this.linuxTray === linuxTray) {
+            linuxTray.destroy();
+            this.linuxTray = null;
+          }
+        });
+      return;
+    }
+
     if (this.tray) {
       return;
     }
@@ -150,9 +188,6 @@ export default class TrayIcon {
     this.tray.setToolTip('Ferdium');
 
     this.trayMenu = Menu.buildFromTemplate(this.trayMenuTemplate(this));
-    if (isLinux) {
-      this.tray.setContextMenu(this.trayMenu);
-    }
 
     this.tray.on('click', () => {
       this._toggleWindow();
@@ -201,6 +236,14 @@ export default class TrayIcon {
   }
 
   _hide(): void {
+    if (isLinux) {
+      if (this.linuxTray) {
+        this.linuxTray.destroy();
+        this.linuxTray = null;
+      }
+      return;
+    }
+
     if (!this.tray) return;
 
     this.tray.destroy();
@@ -224,14 +267,23 @@ export default class TrayIcon {
   }
 
   /**
-   * Refresh the tray icon after a StatusNotifierWatcher restart (e.g. screen
-   * unlock on GNOME). Instead of destroying and recreating the Tray object
-   * (which fails because Electron doesn't clean up D-Bus exports), we call
-   * setImage() which forces Electron to write the icon to a new temp file
-   * and update the IconThemePath property in D-Bus.
+   * Refresh the tray after a StatusNotifierWatcher restart (e.g. screen
+   * unlock on GNOME). The custom Linux StatusNotifierItem can simply
+   * re-register with the watcher. Other platforms keep using Electron Tray.
    */
   refreshTrayAfterWatcherRestart(): void {
-    if (!this.visible || !this.tray) {
+    if (!this.visible) {
+      return;
+    }
+
+    if (isLinux) {
+      if (this.linuxTray) {
+        this.linuxTray.refreshAfterWatcherRestart().catch(() => null);
+      }
+      return;
+    }
+
+    if (!this.tray) {
       return;
     }
 
@@ -259,13 +311,21 @@ export default class TrayIcon {
   }
 
   _refreshIcon(): void {
+    const icon = this._getAsset(
+      'tray',
+      this._getAssetFromIndicator(this.indicator),
+    );
+
+    if (isLinux) {
+      this.linuxTray?.setImage(icon);
+      return;
+    }
+
     if (!this.tray) {
       return;
     }
 
-    this.tray.setImage(
-      this._getAsset('tray', this._getAssetFromIndicator(this.indicator)),
-    );
+    this.tray.setImage(icon);
 
     if (isMac && !macosVersion.isGreaterThanOrEqualTo('11')) {
       this.tray.setPressedImage(


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Replaces Electron's `Tray` implementation on Linux with a native StatusNotifierItem implementation using Ferdium's existing `dbus-next` dependency.

The Linux tray backend:

- Exports both `org.kde.StatusNotifierItem` and `org.freedesktop.StatusNotifierItem` interfaces for compatibility across Linux desktop environments.
- Implements DBusMenu v3 for the tray context menu.
- Supports tray activation/click handling and the existing Ferdium tray actions.
- Exposes the tray icon independently of Electron's Linux `Tray` implementation.
- Re-registers the tray item when the StatusNotifierWatcher restarts.
- Handles both KDE and freedesktop StatusNotifierWatcher implementations.
- Keeps Electron's existing `Tray` implementation unchanged on Windows and macOS.

No Electron version downgrade or dependency changes are required.

Files changed:

- `src/lib/LinuxTray.ts` - new Linux StatusNotifierItem/DBusMenu backend.
- `src/lib/Tray.ts` - uses `LinuxTray` on Linux while retaining Electron `Tray` elsewhere.
- `src/lib/DBus.ts` - re-registers the Linux tray after StatusNotifierWatcher restarts.

#### Motivation and Context

Fixes #2493.

Electron 43 introduced an upstream Linux StatusNotifierItem/D-Bus regression that causes tray hosts to fail when reading properties from Electron's tray item. Depending on the desktop environment, this results in a placeholder icon, a disappearing tray icon, no tray icon, or an icon that does not respond to clicks.

The issue is tracked upstream in electron/electron#52674.

PR #2499 works around the same problem by reverting Electron to 42.9.3. This PR takes a different approach: it bypasses Electron's affected Linux tray implementation while allowing Ferdium to remain on the newer Electron version.

Since Ferdium already depends on `dbus-next`, the workaround can be implemented without adding another dependency or maintaining a custom Electron build.

The resulting platform behavior is:

```text
Windows/macOS
    └── Electron Tray

Linux
    └── dbus-next
        ├── StatusNotifierItem
        └── DBusMenu
```

This confines the workaround to the affected Linux functionality and allows it to be removed once the upstream Electron/Chromium regression is resolved.

#### Screenshots

| Before | After |
|-- |-- |
| <img width="166" height="46" alt="image" src="https://github.com/user-attachments/assets/10274845-e508-4c94-8b3e-83a74428a3a3" /> | <img width="178" height="53" alt="image" src="https://github.com/user-attachments/assets/cd875f96-cc49-409d-b482-9554971cdb4f" /> |

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally on a Linux desktop environment

#### Release Notes

Fix the Linux system tray icon and tray actions on newer Electron versions without downgrading Electron.