### PR TITLE
fix(macOS): decouple background options from system tray

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.tsx
+++ b/src/components/settings/settings/EditSettingsForm.tsx
@@ -460,8 +460,7 @@ class EditSettingsForm extends Component<IProps, IState> {
           values.twoFactorAutoCatcherMatcher =
             DEFAULT_APP_SETTINGS.twoFactorAutoCatcherMatcher;
         }
-
-        if (!values.enableSystemTray) {
+        if (!isMac && !values.enableSystemTray) {
           values.runInBackground = false;
           values.startMinimized = false;
           values.minimizeToSystemTray = false;
@@ -664,7 +663,9 @@ class EditSettingsForm extends Component<IProps, IState> {
                   {intl.formatMessage(messages.sectionMain)}
                 </H2>
                 <Toggle {...form.$('autoLaunchOnStart').bind()} />
+                {isMac && <Toggle {...form.$('runInBackground').bind()} />}
                 <Toggle {...form.$('confirmOnQuit').bind()} />
+                {isMac && <Toggle {...form.$('enableSystemTray').bind()} />}
                 {reloadAfterResume && <Hr />}
                 <Toggle {...form.$('reloadAfterResume').bind()} />
                 {reloadAfterResume && (
@@ -673,20 +674,24 @@ class EditSettingsForm extends Component<IProps, IState> {
                     <Hr />
                   </div>
                 )}
-
-                {enableSystemTray && <Hr />}
-                <Toggle {...form.$('enableSystemTray').bind()} />
-                {enableSystemTray && (
+                {isMac && <Toggle {...form.$('startMinimized').bind()} />}
+                {!isMac && (
                   <>
-                    <Toggle {...form.$('runInBackground').bind()} />
-                    <Toggle {...form.$('startMinimized').bind()} />
-                    {isWindows && (
-                      <Toggle {...form.$('minimizeToSystemTray').bind()} />
+                    {enableSystemTray && <Hr />}
+                    <Toggle {...form.$('enableSystemTray').bind()} />
+                    {enableSystemTray && (
+                      <>
+                        <Toggle {...form.$('runInBackground').bind()} />
+                        <Toggle {...form.$('startMinimized').bind()} />
+                        {isWindows && (
+                          <Toggle {...form.$('minimizeToSystemTray').bind()} />
+                        )}
+                        {isWindows && (
+                          <Toggle {...form.$('closeToSystemTray').bind()} />
+                        )}
+                        <Hr />
+                      </>
                     )}
-                    {isWindows && (
-                      <Toggle {...form.$('closeToSystemTray').bind()} />
-                    )}
-                    <Hr />
                   </>
                 )}
 

--- a/src/containers/settings/EditSettingsScreen.tsx
+++ b/src/containers/settings/EditSettingsScreen.tsx
@@ -420,29 +420,29 @@ class EditSettingsScreen extends Component<
     });
 
     const enableSystemTray = Boolean(settingsData.enableSystemTray);
-
+    const trayDependencySatisfied = isMac || enableSystemTray;
     app.launchOnStartup({
       enable: Boolean(settingsData.autoLaunchOnStart),
       openInBackground:
-        enableSystemTray && Boolean(settingsData.autoLaunchInBackground),
+        trayDependencySatisfied && Boolean(settingsData.autoLaunchInBackground),
     });
 
     debug(`Updating settings store with data: ${settingsData}`);
 
     const { app: currentSettings } = this.props.stores.settings.all;
-
     const newSettings = {
       runInBackground:
-        enableSystemTray && Boolean(settingsData.runInBackground),
+        trayDependencySatisfied && Boolean(settingsData.runInBackground),
       enableSystemTray,
       reloadAfterResume: Boolean(settingsData.reloadAfterResume),
       reloadAfterResumeTime: Number(settingsData.reloadAfterResumeTime),
-      startMinimized: enableSystemTray && Boolean(settingsData.startMinimized),
+      startMinimized:
+        trayDependencySatisfied && Boolean(settingsData.startMinimized),
       confirmOnQuit: Boolean(settingsData.confirmOnQuit),
       minimizeToSystemTray:
-        enableSystemTray && Boolean(settingsData.minimizeToSystemTray),
+        trayDependencySatisfied && Boolean(settingsData.minimizeToSystemTray),
       closeToSystemTray:
-        enableSystemTray && Boolean(settingsData.closeToSystemTray),
+        trayDependencySatisfied && Boolean(settingsData.closeToSystemTray),
       privateNotifications: Boolean(settingsData.privateNotifications),
       clipboardNotifications: Boolean(settingsData.clipboardNotifications),
       notifyTaskBarOnMessage: Boolean(settingsData.notifyTaskBarOnMessage),
@@ -707,7 +707,7 @@ class EditSettingsScreen extends Component<
       settings.all.app.enableSystemTray,
       DEFAULT_APP_SETTINGS.enableSystemTray,
     );
-
+    const trayDependencySatisfied = isMac || isSystemTrayEnabled;
     const config: FormFields = {
       fields: {
         autoLaunchOnStart: {
@@ -731,25 +731,25 @@ class EditSettingsScreen extends Component<
         runInBackground: {
           label: intl.formatMessage(messages.runInBackground),
           value:
-            isSystemTrayEnabled &&
+            trayDependencySatisfied &&
             ifUndefined<boolean>(
               settings.all.app.runInBackground,
               DEFAULT_APP_SETTINGS.runInBackground,
             ),
           default: DEFAULT_APP_SETTINGS.runInBackground,
-          disabled: !isSystemTrayEnabled,
+          disabled: !trayDependencySatisfied,
           type: 'checkbox',
         },
         startMinimized: {
           label: intl.formatMessage(messages.startMinimized),
           value:
-            isSystemTrayEnabled &&
+            trayDependencySatisfied &&
             ifUndefined<boolean>(
               settings.all.app.startMinimized,
               DEFAULT_APP_SETTINGS.startMinimized,
             ),
           default: DEFAULT_APP_SETTINGS.startMinimized,
-          disabled: !isSystemTrayEnabled,
+          disabled: !trayDependencySatisfied,
           type: 'checkbox',
         },
         confirmOnQuit: {
@@ -792,25 +792,25 @@ class EditSettingsScreen extends Component<
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
           value:
-            isSystemTrayEnabled &&
+            trayDependencySatisfied &&
             ifUndefined<boolean>(
               settings.all.app.minimizeToSystemTray,
               DEFAULT_APP_SETTINGS.minimizeToSystemTray,
             ),
           default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
-          disabled: !isSystemTrayEnabled,
+          disabled: !trayDependencySatisfied,
           type: 'checkbox',
         },
         closeToSystemTray: {
           label: intl.formatMessage(messages.closeToSystemTray),
           value:
-            isSystemTrayEnabled &&
+            trayDependencySatisfied &&
             ifUndefined<boolean>(
               settings.all.app.closeToSystemTray,
               DEFAULT_APP_SETTINGS.closeToSystemTray,
             ),
           default: DEFAULT_APP_SETTINGS.closeToSystemTray,
-          disabled: !isSystemTrayEnabled,
+          disabled: !trayDependencySatisfied,
           type: 'checkbox',
         },
         privateNotifications: {

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4115,7 +4115,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Always show Ferdium in Menu Bar",
+        "defaultMessage": "!!!Show Ferdium in Menu Bar",
         "end": {
           "column": 3,
           "line": 53

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -276,7 +276,7 @@
   "settings.app.form.enableGlobalHideShortcut": "Enable Global shortcut to hide Ferdium",
   "settings.app.form.enableLock": "Enable Password Lock",
   "settings.app.form.enableLongPressServiceHint": "Enable service shortcut hint on long press",
-  "settings.app.form.enableMenuBar": "Always show Ferdium in Menu Bar",
+  "settings.app.form.enableMenuBar": "Show Ferdium in Menu Bar",
   "settings.app.form.enableSpellchecking": "Enable spell checking",
   "settings.app.form.enableSystemTray": "Show Ferdium in System Tray",
   "settings.app.form.enableTodos": "Enable Ferdium Todos",

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ const retrieveSettingValue = (key: string, defaultValue: boolean | string) =>
   ifUndefined<boolean | string>(settings.get(key), defaultValue);
 
 const normalizeAppSettings = (): void => {
-  if (settings.get('enableSystemTray') !== false) {
+  if (isMac || settings.get('enableSystemTray') !== false) {
     return;
   }
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Restores the previous macOS behavior for system tray-related settings.

On macOS, `enableSystemTray` does not need to be enabled for Ferdium to run in the background or start minimized, since the application can still be restored through the Dock.

This change:

* Keeps `enableSystemTray`, `runInBackground`, and `startMinimized` independent on macOS.
* Prevents disabling `enableSystemTray` from forcing `runInBackground` or `startMinimized` to `false` on macOS.
* Prevents startup settings normalization from clearing these options on macOS.
* Updates `EditSettingsForm` so the macOS options remain freely selectable instead of being grouped under and dependent on `enableSystemTray`.
* Keeps the system tray dependencies introduced in #2498 unchanged for Windows and Linux.

Closes #2501.

#### Motivation and Context

PR #2498 made `enableSystemTray` the parent setting for options such as `runInBackground` and `startMinimized`.

While that dependency is useful on platforms where the system tray is required to restore a hidden Ferdium window, it introduced a regression on macOS.

On macOS, Ferdium can run in the background without showing a system tray/menu bar icon because the application remains available through the Dock. As a result, disabling `enableSystemTray` should not disable or clear `runInBackground` or `startMinimized`.

After #2498, disabling the system tray could cause `runInBackground` to be cleared. Closing the Ferdium window would then leave users unable to restore it by clicking the Dock icon, as reported in #2501.

This change restores the macOS behavior from before #2498 while retaining the new dependency handling on Windows and Linux.

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally

#### Release Notes

notes: Fixed a macOS regression where disabling the system tray could prevent Ferdium from continuing to run in the background and being restored from the Dock.