### PR TITLE
build: add ZIP artifact for Windows ARM64

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -97,6 +97,9 @@ win:
       arch: [x64, ia32, arm64]
     - target: portable
       arch: [x64, ia32, arm64]
+    # Temporary ARM64 ZIP build
+    - target: zip
+      arch: [arm64]
   # The name of the CN appearing in the certificate must be present in the publisherName list below
   signtoolOptions:
     publisherName: ["Ferdium Contributors", "Ambroise Grau"]


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Adds a ZIP build target for Windows ARM64:

```yaml
- target: zip
  arch: [arm64]
```

This provides ARM64 users with an unpacked Ferdium build that does not depend on the NSIS installer.

#### Motivation and Context

This provides a temporary workaround for #2502, where the Windows ARM64 NSIS installer completes successfully but does not install `Ferdium.exe`.

The generated `app-arm64.7z` has been verified to contain `Ferdium.exe`, indicating that the ARM64 build itself is correct and the failure occurs during the upstream `electron-builder`/`Nsis7z` installation process.

This is related to the upstream issue [electron-builder#9983](https://github.com/electron-userland/electron-builder/issues/9983).

Publishing an ARM64 ZIP allows affected users to extract and run the latest Ferdium version while the upstream installer issue remains unresolved.

#### Checklist

* [x] My pull request is properly named
* [x] I tested/previewed my changes locally

#### Release Notes

Add a ZIP build for Windows ARM64 as a workaround for the current NSIS installer issue.