### PR TITLE
Enable ASAR integrity validation and restrict app loading

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,6 +4,10 @@ directories:
 
 appId: "org.ferdium.ferdium-app"
 
+electronFuses:
+  enableEmbeddedAsarIntegrityValidation: true
+  onlyLoadAppFromAsar: true
+
 publish:
   provider: github
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Enable Electron's ASAR integrity protection through `electron-builder` by configuring the following Electron fuses:

* `enableEmbeddedAsarIntegrityValidation`
* `onlyLoadAppFromAsar`

`enableEmbeddedAsarIntegrityValidation` validates the packaged `app.asar` at runtime on supported platforms and terminates the application if its integrity check fails.

`onlyLoadAppFromAsar` restricts Electron's application code lookup to `app.asar`, preventing the integrity protection from being bypassed through fallback locations such as `resources/app`.

Together, these options provide tamper protection for Ferdium's packaged application code without requiring a custom `afterPack` hook or additional runtime code.

#### Motivation and Context

Fixes #2138.

Without ASAR integrity validation, an attacker with the ability to modify a Ferdium installation may replace or inject application code and have it executed as Ferdium.

Electron recommends enabling `onlyLoadAppFromAsar` together with embedded ASAR integrity validation, as otherwise the normal application lookup path can allow Electron to load code outside the validated archive.

The current `electron-builder` version used by Ferdium supports configuring these Electron fuses directly, making this a small packaging configuration change.

This change is intentionally limited to protecting Ferdium's main packaged application archive. It does not change the existing behavior of unpacked assets or Ferdium's recipe/custom JavaScript system.

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally

#### Release Notes

Improve Ferdium's tamper protection by enabling integrity validation for the packaged application.
