### PR TITLE
fix: clear service browser storage before reload or deletion

### DIFF
--- a/src/api/server/LocalApi.ts
+++ b/src/api/server/LocalApi.ts
@@ -56,7 +56,10 @@ export default class LocalApi {
         'cachestorage',
       ],
     };
-    ipcRenderer.send('clear-storage-data', { serviceId, targetsToClear });
+    await ipcRenderer.invoke('clear-storage-data', {
+      serviceId,
+      targetsToClear,
+    });
     return ipcRenderer.invoke('clear-cache', { serviceId });
   }
 }

--- a/src/api/server/ServerApi.ts
+++ b/src/api/server/ServerApi.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-import-module-exports */
 /* eslint-disable global-require */
 import { join } from 'node:path';
+import { ipcRenderer } from 'electron';
 import {
   type PathOrFileDescriptor,
   copySync,
@@ -321,6 +322,16 @@ export default class ServerApi {
       throw new Error(request.statusText);
     }
     const data = await request.json();
+
+    // Chromium keeps persistent service sessions alive independently of the
+    // webview. Clear browser storage first so a locked partition cannot retain
+    // a corrupt IndexedDB database (for example WhatsApp's login database)
+    // while filesystem cleanup is deferred until the next app start.
+    try {
+      await ipcRenderer.invoke('clear-storage-data', { serviceId: id });
+    } catch (error) {
+      debug('Unable to clear service storage before partition removal', error);
+    }
 
     removeServicePartitionDirectory(id, true);
 

--- a/src/electron/ipc-api/sessionStorage.ts
+++ b/src/electron/ipc-api/sessionStorage.ts
@@ -15,22 +15,24 @@ const deduceSession = (serviceId: string | undefined | null): Session => {
 };
 
 export default async () => {
-  ipcMain.on('clear-storage-data', (_event, { serviceId, targetsToClear }) => {
-    try {
-      const serviceSession = deduceSession(serviceId);
-      serviceSession.flushStorageData();
-      if (targetsToClear) {
-        debug('Clearing targets:', targetsToClear);
-        serviceSession.clearStorageData(targetsToClear);
-      } else {
-        debug('Clearing all targets');
-        serviceSession.clearStorageData();
+  ipcMain.handle(
+    'clear-storage-data',
+    async (_event, { serviceId, targetsToClear }) => {
+      try {
+        const serviceSession = deduceSession(serviceId);
+        serviceSession.flushStorageData();
+        if (targetsToClear) {
+          debug('Clearing targets:', targetsToClear);
+          await serviceSession.clearStorageData(targetsToClear);
+        } else {
+          debug('Clearing all targets');
+          await serviceSession.clearStorageData();
+        }
+      } catch (error) {
+        debug(error);
       }
-    } catch (error) {
-      debug(error);
-    }
-  });
-
+    },
+  );
   ipcMain.handle('clear-cache', (_event, { serviceId }) => {
     const serviceSession = deduceSession(serviceId);
     return serviceSession.clearCache();


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

This PR fixes service browser storage cleanup so that persistent Chromium storage is fully cleared before a service is reloaded or removed.

The `clear-storage-data` IPC flow previously triggered Electron's asynchronous `session.clearStorageData()` operation without waiting for it to finish. This could allow a service to reload while stale or corrupted browser storage, including IndexedDB data, was still present.

The changes:

* Make the `clear-storage-data` IPC handler asynchronous and wait for `session.clearStorageData()` to complete.
* Make the renderer-side storage clearing call await completion before continuing.
* Ensure service cache/storage cleanup completes before subsequent reload operations.
* Clear the live Electron session storage when deleting a service before removing its persistent service partition.
* Add regression coverage for asynchronous storage clearing and cleanup ordering.

#### Motivation and Context

Fixes #2464.

WhatsApp can fail during startup with a browser database error instead of displaying the QR login screen. Removing and recreating the service does not necessarily recover it because Ferdium uses persistent Chromium partitions for services, allowing corrupted browser database state to survive.

This change makes storage cleanup deterministic by waiting for Electron to finish clearing browser storage before Ferdium reloads or removes the affected service.

Although reported with WhatsApp, the fix is implemented at the service/session level so other services affected by corrupted IndexedDB or related Chromium storage can recover through the same cleanup path.

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally

#### Release Notes

Fix service login failures caused by stale or corrupted browser database storage.