### PR TITLE
ci: Add stale issue and pull request automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,90 @@
+name: Stale issues and pull requests
+
+on:
+  #schedule:
+  #  # Avoid the existing midnight nightly build schedule.
+  #  - cron: "17 3 * * *"
+
+  workflow_dispatch:
+    inputs:
+      debug_only:
+        description: "Dry run without modifying issues or pull requests"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Process stale issues and pull requests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues
+          days-before-issue-stale: 120
+          days-before-issue-close: 30
+
+          stale-issue-label: stale
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had no
+            activity for 120 days.
+
+            Please test this issue again using the latest version of Ferdium and let us
+            know whether the problem is still reproducible. If it is, please leave a
+            comment with the Ferdium version you tested and any updated information that
+            may help us investigate.
+
+            Any new activity will remove the stale label. If there is no further activity,
+            this issue will be automatically closed in 30 days.
+
+          close-issue-message: >
+            This issue was automatically closed after an additional 30 days without
+            activity.
+
+            If you can reproduce the issue on the latest version of Ferdium, please leave
+            updated reproduction details, including the Ferdium version you tested, so
+            the issue can be reconsidered.
+
+          close-issue-reason: not_planned
+
+          # Recipe requests are intentionally long-lived and MUST NOT
+          # participate in stale processing.
+          exempt-issue-labels: "recipe request :sparkles:"
+
+          # Pull requests
+          days-before-pr-stale: 60
+          days-before-pr-close: -1
+
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has had no activity for 60 days and has been
+            marked as stale. It will not be closed automatically. A new commit
+            or comment will remove the stale label.
+
+          exempt-draft-pr: true
+
+          # Large existing backlog: process incrementally.
+          operations-per-run: 100
+          ascending: true
+
+          remove-stale-when-updated: true
+
+          # workflow_dispatch defaults to a safe dry run.
+          # Scheduled executions are live.
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_only }}


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Adds a GitHub Actions workflow using `actions/stale` to help manage inactive issues and pull requests.

The workflow:

* Marks issues as stale after 120 days of inactivity.
* Automatically closes stale issues after an additional 30 days without activity.
* Asks issue reporters to test the latest version of Ferdium and confirm whether the issue is still reproducible before it is closed.
* Removes the stale label when new activity occurs.
* Completely excludes issues labeled `recipe request :sparkles:` from stale processing.
* Marks pull requests as stale after 60 days of inactivity, but does not automatically close them.
* Excludes draft pull requests from stale processing.
* Limits the number of operations per run to gradually process the existing backlog.
* Processes older issues and pull requests first.
* Supports manual dry runs through `workflow_dispatch` so the affected issues and pull requests can be reviewed before enabling the scheduled execution.

The scheduled trigger is intentionally disabled for the initial rollout. Once the dry-run results have been validated, it can be enabled in a follow-up change.

#### Motivation and Context

Ferdium has a large number of long-running issues, including reports that may no longer be reproducible on current versions of the application.

This automation helps keep the issue tracker relevant by prompting reporters of inactive issues to test the latest Ferdium version and provide updated reproduction information.

The policy is intentionally conservative to avoid prematurely closing potentially valid reports. Recipe requests are explicitly excluded because they represent a long-lived request queue rather than issues that become invalid through inactivity.

Pull requests are also never automatically closed, allowing maintainers to decide how to handle older contributions.

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes - not applicable, no application code was changed
* [x] I tested/previewed my changes locally

The workflow will also be validated using its `debug_only` dry-run mode before scheduled stale processing is enabled.