### PR TITLE
Fix linux tray icon issues

### DIFF
--- a/src/lib/LinuxTray.ts
+++ b/src/lib/LinuxTray.ts
@@ -1,10 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/class-literal-property-style */
 /* eslint-disable max-classes-per-file */
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import * as dbus from 'dbus-next';
 import type { MessageBus } from 'dbus-next';
 import { type NativeImage, nativeImage } from 'electron';
@@ -75,24 +71,48 @@ function makeStatusNotifierPixmap(image: NativeImage): StatusNotifierPixmap {
     return [];
   }
 
-  const bitmap = image.toBitmap();
-  const expectedLength = width * height * 4;
-  if (bitmap.length < expectedLength) {
-    return [];
-  }
-
   const format = getNativeBitmapFormat();
-  const argb = Buffer.alloc(expectedLength);
-  for (let offset = 0; offset < expectedLength; offset += 4) {
-    const redOffset = format === 'rgba' ? offset : offset + 2;
-    const blueOffset = format === 'rgba' ? offset + 2 : offset;
-    argb[offset] = bitmap[offset + 3];
-    argb[offset + 1] = bitmap[redOffset];
-    argb[offset + 2] = bitmap[offset + 1];
-    argb[offset + 3] = bitmap[blueOffset];
+  const scaleFactors = image.getScaleFactors();
+  const pixmaps: StatusNotifierPixmap = [];
+
+  for (const scale of scaleFactors.length > 0 ? scaleFactors : [1]) {
+    const scaledWidth = Math.round(width * scale);
+    const scaledHeight = Math.round(height * scale);
+    const bitmap = image.toBitmap({ scaleFactor: scale });
+    const expectedLength = scaledWidth * scaledHeight * 4;
+
+    if (bitmap.length >= expectedLength) {
+      const argb = Buffer.alloc(expectedLength);
+      for (let offset = 0; offset < expectedLength; offset += 4) {
+        const redOffset = format === 'rgba' ? offset : offset + 2;
+        const blueOffset = format === 'rgba' ? offset + 2 : offset;
+        argb[offset] = bitmap[offset + 3];
+        argb[offset + 1] = bitmap[redOffset];
+        argb[offset + 2] = bitmap[offset + 1];
+        argb[offset + 3] = bitmap[blueOffset];
+      }
+      pixmaps.push([scaledWidth, scaledHeight, argb]);
+    }
   }
 
-  return [[width, height, argb]];
+  if (pixmaps.length === 0) {
+    const bitmap = image.toBitmap();
+    const expectedLength = width * height * 4;
+    if (bitmap.length >= expectedLength) {
+      const argb = Buffer.alloc(expectedLength);
+      for (let offset = 0; offset < expectedLength; offset += 4) {
+        const redOffset = format === 'rgba' ? offset : offset + 2;
+        const blueOffset = format === 'rgba' ? offset + 2 : offset;
+        argb[offset] = bitmap[offset + 3];
+        argb[offset + 1] = bitmap[redOffset];
+        argb[offset + 2] = bitmap[offset + 1];
+        argb[offset + 3] = bitmap[blueOffset];
+      }
+      pixmaps.push([width, height, argb]);
+    }
+  }
+
+  return pixmaps;
 }
 
 class StatusNotifierItem extends dbus.interface.Interface {
@@ -477,13 +497,7 @@ export default class LinuxTray {
 
   private readonly serviceName = `org.freedesktop.StatusNotifierItem-${process.pid}-1`;
 
-  private iconDirectory: string | null = null;
-
-  private currentIconName = '';
-
   private currentIconPixmap: StatusNotifierPixmap = [];
-
-  private iconRevision = 0;
 
   private active = false;
 
@@ -498,11 +512,11 @@ export default class LinuxTray {
   }
 
   get iconName(): string {
-    return this.currentIconName;
+    return '';
   }
 
   get iconThemePath(): string {
-    return this.iconDirectory ?? '';
+    return '';
   }
 
   get iconPixmap(): StatusNotifierPixmap {
@@ -570,32 +584,12 @@ export default class LinuxTray {
       return;
     }
 
-    const nextDirectory = mkdtempSync(join(tmpdir(), 'ferdium-tray-'));
-    this.iconRevision += 1;
-    const nextIconName = `ferdium-tray-${this.iconRevision}`;
-    const nextIconPath = join(nextDirectory, `${nextIconName}.png`);
-
-    try {
-      writeFileSync(nextIconPath, Uint8Array.from(image.toPNG()));
-    } catch (error) {
-      rmSync(nextDirectory, { recursive: true, force: true });
-      throw error;
-    }
-
-    const previousDirectory = this.iconDirectory;
-    this.iconDirectory = nextDirectory;
-    this.currentIconName = nextIconName;
     this.currentIconPixmap = makeStatusNotifierPixmap(image);
 
     if (this.exported) {
       for (const statusNotifierItem of this.statusNotifierItems) {
-        statusNotifierItem.NewIconThemePath(nextDirectory);
         statusNotifierItem.NewIcon();
       }
-    }
-
-    if (previousDirectory) {
-      rmSync(previousDirectory, { recursive: true, force: true });
     }
   }
 
@@ -614,7 +608,6 @@ export default class LinuxTray {
 
     await this.registerWithWatcher();
     for (const statusNotifierItem of this.statusNotifierItems) {
-      statusNotifierItem.NewIconThemePath(this.iconThemePath);
       statusNotifierItem.NewIcon();
     }
   }
@@ -659,11 +652,6 @@ export default class LinuxTray {
       this.bus = null;
     }
 
-    if (this.iconDirectory) {
-      rmSync(this.iconDirectory, { recursive: true, force: true });
-      this.iconDirectory = null;
-      this.currentIconName = '';
-      this.currentIconPixmap = [];
-    }
+    this.currentIconPixmap = [];
   }
 }

--- a/src/lib/Tray.ts
+++ b/src/lib/Tray.ts
@@ -98,12 +98,12 @@ export default class TrayIcon {
           ? getTranslatedText(
               tray.currentLocale,
               'tray.enableNotifications',
-              'Enable Notifications && Audio',
+              'Enable Notifications & Audio',
             )
           : getTranslatedText(
               tray.currentLocale,
               'tray.disableNotifications',
-              'Disable Notifications && Audio',
+              'Disable Notifications & Audio',
             ),
         click() {
           if (!tray.mainWindow) return;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- Makes it so the correct tray icon is displayed on Linux, as opposed to displaying the default application icon (purple circle);
- Fix Unread messages indicator not displaying, which was a consequence of the issue on the point above;
- Fix menu item captions for tray context menu.

#### Motivation and Context
This fixes #2518 , that was introduced in #2504 which was itself a workaround for a regression in Tray icon handling in Electron 43 on Linux. The underlying problem was that the code added specifically for Tray handling in Linux:
1. In LinuxTray.ts, when setImage() was called, it wrote the PNG to a temporary directory (e.g. /tmp/ferdium-tray-XXXXXX/ferdium-tray-1.png), and set:
  • IconName: "ferdium-tray-1"
  • IconThemePath: "/tmp/ferdium-tray-XXXXXX"
  • IconPixmap: ARGB pixmap byte array
2. According to the FreeDesktop StatusNotifierItem specification, system tray hosts (such as GNOME Shell's AppIndicator / KStatusNotifierItem extension and KDE Plasma) check IconName first before IconPixmap.
3. In GNOME Shell (St.IconTheme) and KDE (KIconLoader), IconThemePath expects a standard FreeDesktop Icon Theme directory structure (with index.theme and subdirectories like hicolor/<size>/apps/). A flat /tmp directory containing only ferdium-tray-1.png is not a valid icon theme, so theme lookup for "ferdium-tray-1" fails.
4. Because IconName was provided (non-empty), GNOME's AppIndicator extension does not fall back to IconPixmap.
5. When icon lookup fails, desktop environments fall back to displaying the application's window/desktop entry icon (Id: "ferdium" / matched via window PID), which is the full-color Ferdium app icon (256x256.png).

The applied fix was:
1. Leave IconName and IconThemePath empty (""): When IconName is empty, SNI hosts (GNOME AppIndicator, KDE Plasma, Waybar, XFCE, etc.) immediately use the in-memory ARGB byte array sent over D-Bus.
2. Remove the temporary file/directory creation: There is no need to write files to /tmp via mkdtempSync and writeFileSync on every indicator change.
3. **Improvement**: Include multi-scale representations in LinuxTray.ts: LinuxTray.ts provides both 1× (64×64) and 2× (128×128) bitmaps, which can both be passed in IconPixmap so HiDPI screens render the tray icon crisply.

**Unrelated to the main scope of this PR:** I've also fixed the menu item captions for the tray context menu in Tray.ts: It was displayed as "Disable Notifications && Audio". But since the `trayMenuTemplate` method is supposed to be used for all platforms (even though it returns a `LinuxTrayMenuItem` type? :thinking: ), I'm not sure if the double ampersands were some sort of escaping required by Electron's tray icon handling, so I'd be grateful if someone can test this on Windows & Mac.

#### Screenshots
Correct icon + menu item captions:
<img width="245" height="97" alt="image" src="https://github.com/user-attachments/assets/d671bddc-e8a4-4d70-b2bb-b9de6a662e72" />
Indicator showing for unread messages:
<img width="38" height="97" alt="image" src="https://github.com/user-attachments/assets/b5087ae2-ff97-4a36-8aea-697ca866c9a4" />


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`pnpm prepare-code`)
- [X] `pnpm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes
- Fix Tray icon image shown in Linux