### PR TITLE
fix: clean up service tab and Todos event listeners

### DIFF
--- a/src/components/services/tabs/TabItem.tsx
+++ b/src/components/services/tabs/TabItem.tsx
@@ -2,7 +2,13 @@ import { Menu, app, dialog } from '@electron/remote';
 import { mdiExclamation, mdiVolumeSource } from '@mdi/js';
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import { autorun, makeObservable, observable, reaction } from 'mobx';
+import {
+  type IReactionDisposer,
+  autorun,
+  makeObservable,
+  observable,
+  reaction,
+} from 'mobx';
 import { inject, observer } from 'mobx-react';
 import ms from 'ms';
 import { Component } from 'react';
@@ -156,6 +162,10 @@ class TabItem extends Component<IProps, IState> {
 
   private pollAnswerTimeoutId: NodeJS.Timeout | null = null;
 
+  private longPressReactionDisposer: IReactionDisposer | null = null;
+
+  private pollReactionDisposer: IReactionDisposer | null = null;
+
   constructor(props) {
     super(props);
 
@@ -164,15 +174,6 @@ class TabItem extends Component<IProps, IState> {
     this.state = {
       showShortcutIndex: false,
     };
-
-    reaction(
-      () => this.props.stores!.settings.app.enableLongPressServiceHint,
-      () => {
-        this.checkForLongPress(
-          this.props.stores!.settings.app.enableLongPressServiceHint,
-        );
-      },
-    );
   }
 
   handleShortcutIndex = (event: KeyboardEvent, showShortcutIndex = true) => {
@@ -181,23 +182,38 @@ class TabItem extends Component<IProps, IState> {
     }
   };
 
-  checkForLongPress = enableLongPressServiceHint => {
-    if (enableLongPressServiceHint) {
-      document.addEventListener('keydown', e => {
-        this.handleShortcutIndex(e);
-      });
+  handleShortcutKeyDown = (event: KeyboardEvent): void => {
+    this.handleShortcutIndex(event);
+  };
 
-      document.addEventListener('keyup', e => {
-        this.handleShortcutIndex(e, false);
-      });
+  handleShortcutKeyUp = (event: KeyboardEvent): void => {
+    this.handleShortcutIndex(event, false);
+  };
+
+  checkForLongPress = (enableLongPressServiceHint: boolean): void => {
+    if (enableLongPressServiceHint) {
+      document.addEventListener('keydown', this.handleShortcutKeyDown);
+      document.addEventListener('keyup', this.handleShortcutKeyUp);
+    } else {
+      document.removeEventListener('keydown', this.handleShortcutKeyDown);
+      document.removeEventListener('keyup', this.handleShortcutKeyUp);
+      if (this.state.showShortcutIndex) {
+        this.setState({ showShortcutIndex: false });
+      }
     }
   };
 
   componentDidMount() {
     const { service, stores } = this.props;
 
+    this.longPressReactionDisposer = reaction(
+      () => stores!.settings.app.enableLongPressServiceHint,
+      this.checkForLongPress,
+      { fireImmediately: true },
+    );
+
     if (IS_SERVICE_DEBUGGING_ENABLED) {
-      autorun(() => {
+      this.pollReactionDisposer = autorun(() => {
         if (Date.now() - service.lastPoll < ms('0.2s')) {
           this.isPolled = true;
 
@@ -223,11 +239,13 @@ class TabItem extends Component<IProps, IState> {
         }
       });
     }
-
-    this.checkForLongPress(stores!.settings.app.enableLongPressServiceHint);
   }
 
   componentWillUnmount() {
+    this.longPressReactionDisposer?.();
+    this.pollReactionDisposer?.();
+    document.removeEventListener('keydown', this.handleShortcutKeyDown);
+    document.removeEventListener('keyup', this.handleShortcutKeyUp);
     if (this.pollTimeoutId) {
       clearTimeout(this.pollTimeoutId);
     }

--- a/src/features/todos/components/TodosWebview.tsx
+++ b/src/features/todos/components/TodosWebview.tsx
@@ -76,7 +76,7 @@ interface IState {
 class TodosWebview extends Component<IProps, IState> {
   private node = createRef<HTMLDivElement>();
 
-  private webview: Webview;
+  private webview: Webview | null = null;
 
   constructor(props: IProps) {
     super(props);
@@ -161,10 +161,7 @@ class TodosWebview extends Component<IProps, IState> {
       return;
     }
 
-    const { handleClientMessage } = this.props;
-    this.webview.addEventListener('ipc-message', e => {
-      handleClientMessage(e.channel, e.args[0]);
-    });
+    this.webview.addEventListener('ipc-message', this.handleIpcMessage);
   };
 
   stopListeningToIpcMessages = (): void => {
@@ -172,8 +169,23 @@ class TodosWebview extends Component<IProps, IState> {
       return;
     }
 
-    const { handleClientMessage } = this.props;
-    this.webview.removeEventListener('ipc-message', handleClientMessage);
+    this.webview.removeEventListener('ipc-message', this.handleIpcMessage);
+  };
+
+  handleIpcMessage = (event: Electron.IpcMessageEvent): void => {
+    this.props.handleClientMessage(event.channel, event.args[0]);
+  };
+
+  handleWebviewRef = (webview: Webview | null): void => {
+    this.stopListeningToIpcMessages();
+    this.webview = webview ? webview.view : null;
+  };
+
+  handleDidAttach = (): void => {
+    if (this.webview) {
+      this.props.setTodosWebview(this.webview);
+      this.startListeningToIpcMessages();
+    }
   };
 
   render(): ReactElement {
@@ -224,16 +236,10 @@ class TodosWebview extends Component<IProps, IState> {
         {isTodoUrlValid && (
           <Webview
             // className={classes.webview} // TODO: [TS DEBT] style not found
-            onDidAttach={() => {
-              const { setTodosWebview } = this.props;
-              setTodosWebview(this.webview);
-              this.startListeningToIpcMessages();
-            }}
+            onDidAttach={this.handleDidAttach}
             partition={TODOS_PARTITION_ID}
             preload="./features/todos/preload.js"
-            ref={webview => {
-              this.webview = webview ? webview.view : null;
-            }}
+            ref={this.handleWebviewRef}
             useragent={userAgent}
             src={todoUrl}
             allowpopups


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md).
- [x] I agree to follow the project's [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md).

#### Description of Change

Use stable keyboard callbacks in service tabs, remove them when long-press hints are disabled, and dispose both MobX reactions on unmount. Disabling the setting also hides an already-visible hint.

For Todos, register and remove the same IPC callback, read the latest callback prop, and detach listeners before replacing the webview reference. Stable React ref/attach callbacks avoid needless ref churn.

This prevents accumulated callbacks, post-unmount updates, and duplicated Todos IPC delivery.

#### Reproduction and Verification

Isolated checks covering 20 setting-toggle cycles show 21 keydown listeners before the fix versus one after it. After unmount, there are no keyboard listeners, pending debug timers, or state updates. Todos checks cover repeated attach, replacement, unmount, and changed callback props: one delivery using the latest callback and zero retained listeners.

Validated independently on this branch with Node 24.18.1 / pnpm 11.20.0:

- `pnpm typecheck`.
- ESLint with zero warnings, Prettier, and Biome on the changed files.
- Existing Jest suite: 14 suites passed; 119 tests passed, 2 existing skips.
- Source build via `preval-build-info-cli` and `node esbuild.mjs`.
- `git diff --check`.

The Node-only Jest run used `ELECTRON_OVERRIDE_DIST_PATH="$PWD/node_modules/electron/dist" pnpm test --runInBand --coverageReporters=text-summary` to avoid Electron's lazy binary download. No Electron GUI was launched, and native cross-platform interaction / packaged installers were not tested. No test files were added or changed; the targeted old/new comparisons were isolated runtime checks.

#### Release Notes

Prevent service-tab and Todos listeners from accumulating or updating unmounted components.
