### PR TITLE
perf: skip redundant synchronous settings writes

### DIFF
--- a/src/electron/Settings.ts
+++ b/src/electron/Settings.ts
@@ -32,9 +32,8 @@ export default class Settings {
       return;
     }
 
+    this._writeFile(nextSettings);
     this.store = nextSettings;
-
-    this._writeFile();
   }
 
   get all(): object {
@@ -58,11 +57,11 @@ export default class Settings {
     debug('Hydrate store', this.type, this.allSerialized);
   }
 
-  _writeFile(): void {
-    outputJsonSync(this.settingsFile, this.store, {
+  _writeFile(settings: object = this.store): void {
+    outputJsonSync(this.settingsFile, settings, {
       spaces: 2,
     });
-    debug('Write settings file', this.type, this.allSerialized);
+    debug('Write settings file', this.type, toJS(settings));
   }
 
   get settingsFile(): string {

--- a/src/electron/Settings.ts
+++ b/src/electron/Settings.ts
@@ -1,4 +1,5 @@
 import { outputJsonSync, pathExistsSync, readJsonSync } from 'fs-extra';
+import { isEqual } from 'lodash';
 import { makeObservable, observable, toJS } from 'mobx';
 import { userDataPath } from '../environment-remote';
 
@@ -26,7 +27,12 @@ export default class Settings {
   }
 
   set(settings: object): void {
-    this.store = this._merge(settings);
+    const nextSettings = this._merge(settings);
+    if (isEqual(this.store, nextSettings)) {
+      return;
+    }
+
+    this.store = nextSettings;
 
     this._writeFile();
   }
@@ -44,7 +50,7 @@ export default class Settings {
   }
 
   _merge(settings: object): object {
-    return Object.assign(this.defaultState, this.store, settings);
+    return { ...this.defaultState, ...this.store, ...settings };
   }
 
   _hydrate(): void {


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md).
- [x] I agree to follow the project's [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md).

#### Description of Change

Merge settings into a fresh object, then skip observable replacement and synchronous JSON writes when the merged settings are unchanged.

This avoids repeated main-process filesystem work for duplicate settings updates, including the startup settings round-trip. Actual changes are written before publishing the new observable state, so a failed write leaves the old state intact and can be retried. No debounce or shutdown-flush behavior is introduced.

The non-mutating merge also keeps the supplied defaults from being overwritten during hydration and subsequent updates. This uses the existing lodash dependency.

#### Reproduction and Verification

An isolated check sending 100 identical nested settings updates records 100 synchronous writes before the change and zero after it. A subsequent real change still writes once. Hydration/merge behavior, initial file creation, immutable defaults, preservation of existing keys, and retry after a simulated disk-write failure were also checked.

Validated independently on this branch with Node 24.18.1 / pnpm 11.20.0:

- `pnpm typecheck`.
- ESLint with zero warnings, Prettier, and Biome on the changed files.
- Existing Jest suite: 14 suites passed; 119 tests passed, 2 existing skips.
- Source build via `preval-build-info-cli` and `node esbuild.mjs`.
- `git diff --check`.

The Node-only Jest run used `ELECTRON_OVERRIDE_DIST_PATH="$PWD/node_modules/electron/dist" pnpm test --runInBand --coverageReporters=text-summary` to avoid Electron's lazy binary download. No Electron GUI was launched, and native cross-platform interaction / packaged installers were not tested. No test files were added or changed; the targeted old/new comparisons were isolated runtime checks.

#### Release Notes

Avoid redundant synchronous settings writes and preserve default settings during merging.
