### PR TITLE
perf: avoid repeated cache directory scans in Advanced settings

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -10,7 +10,13 @@ import {
 import AutoLaunch from 'auto-launch';
 import { ipcRenderer } from 'electron';
 import { readJsonSync, readdirSync, writeJsonSync } from 'fs-extra';
-import { action, computed, makeObservable, observable } from 'mobx';
+import {
+  action,
+  computed,
+  makeObservable,
+  observable,
+  onBecomeObserved,
+} from 'mobx';
 import moment from 'moment';
 import ms from 'ms';
 import { v4 as uuidV4 } from 'uuid';
@@ -39,6 +45,7 @@ import {
 import { openExternalUrl } from '../helpers/url-helpers';
 import generatedTranslations from '../i18n/translations';
 import { cleanseJSObject } from '../jsUtils';
+import CachedRequest from './lib/CachedRequest';
 import Request from './lib/Request';
 import TypedStore from './lib/TypedStore';
 
@@ -96,7 +103,7 @@ export default class AppStore extends TypedStore {
 
   @observable sandboxServices: SandboxServices[] = [];
 
-  @observable getAppCacheSizeRequest = new Request(
+  @observable getAppCacheSizeRequest = new CachedRequest(
     this.api.local,
     'getAppCacheSize',
   );
@@ -144,6 +151,10 @@ export default class AppStore extends TypedStore {
     super(stores, api, actions);
 
     makeObservable(this);
+
+    onBecomeObserved(this, 'cacheSize', () => {
+      this.getAppCacheSizeRequest.invalidate();
+    });
 
     // Register action handlers
     this.actions.app.notify.listen(this._notify.bind(this));
@@ -650,7 +661,7 @@ export default class AppStore extends TypedStore {
 
     await sleep(ms('1s'));
 
-    this.getAppCacheSizeRequest.execute();
+    this.getAppCacheSizeRequest.invalidate({ immediately: true });
 
     this.isClearingAllCache = false;
   }


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md).
- [x] I agree to follow the project's [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md).

#### Description of Change

Use the existing CachedRequest for cache-size measurements. The previous computed getter executed an uncached request, so each changed result could cause another directory scan when the observed getter recomputed.

Invalidate when cache size becomes observed, so reopening Advanced settings requests a fresh measurement. Explicitly invalidate after clearing cache as well.

The displayed size is a snapshot while Advanced settings remains open, refreshed on reopening or after clearing; it no longer continuously rescans an actively changing cache. No new polling timer or dependency is introduced.

#### Reproduction and Verification

An isolated check observes the actual store with a mocked cache-size API returning a changing value. The old implementation repeatedly rescans as results arrive; the new implementation performs exactly one measurement. Reopening the observer and clearing cache each trigger exactly one additional measurement. These are call-count checks, not claims about measured application CPU usage.

Validated independently on this branch with Node 24.18.1 / pnpm 11.20.0:

- `pnpm typecheck`.
- ESLint with zero warnings, Prettier, and Biome on the changed files.
- Existing Jest suite: 14 suites passed; 119 tests passed, 2 existing skips.
- Source build via `preval-build-info-cli` and `node esbuild.mjs`.
- `git diff --check`.

The Node-only Jest run used `ELECTRON_OVERRIDE_DIST_PATH="$PWD/node_modules/electron/dist" pnpm test --runInBand --coverageReporters=text-summary` to avoid Electron's lazy binary download. No Electron GUI was launched, and native cross-platform interaction / packaged installers were not tested. No test files were added or changed; the targeted old/new comparisons were isolated runtime checks.

#### Release Notes

Avoid repeated cache directory scans while Advanced settings is open.
