### PR TITLE
perf: reduce blocking work when switching services

### DIFF
--- a/src/components/services/content/ServiceWebview.tsx
+++ b/src/components/services/content/ServiceWebview.tsx
@@ -66,14 +66,16 @@ class ServiceWebview extends Component<IProps> {
     debug('Service logged a message:', e.message);
   };
 
-  handleDidNavigate = (): void => {
+  @action handleDidNavigate = (): void => {
     if (this.props.service._webview) {
-      document.title = `Ferdium - ${this.props.service.name} ${
-        this.props.service.dialogTitle
-          ? ` - ${this.props.service.dialogTitle}`
-          : ''
-      } ${`- ${this.props.service._webview.getTitle()}`}`;
+      this.props.service.pageTitle = this.props.service._webview.getTitle();
     }
+  };
+
+  @action handlePageTitleUpdated = (
+    event: Electron.PageTitleUpdatedEvent,
+  ): void => {
+    this.props.service.pageTitle = event.title;
   };
 
   handleWebviewRef = (webview: ElectronWebView | null): void => {
@@ -108,13 +110,6 @@ class ServiceWebview extends Component<IProps> {
     if (this.props.service.isActive) {
       webview.view.blur();
       webview.view.focus();
-      window.setTimeout(() => {
-        document.title = `Ferdium - ${this.props.service.name} ${
-          this.props.service.dialogTitle
-            ? ` - ${this.props.service.dialogTitle}`
-            : ''
-        } ${`- ${this.props.service._webview.getTitle()}`}`;
-      }, 100);
     } else {
       debug('Refocus not required - Not active service');
     }
@@ -127,6 +122,7 @@ class ServiceWebview extends Component<IProps> {
 
     webview.addEventListener('console-message', this.handleConsoleMessage);
     webview.addEventListener('did-navigate', this.handleDidNavigate);
+    webview.addEventListener('page-title-updated', this.handlePageTitleUpdated);
     webview.addEventListener('did-stop-loading', this.refocusWebview);
   }
 
@@ -137,6 +133,10 @@ class ServiceWebview extends Component<IProps> {
 
     webview.removeEventListener('console-message', this.handleConsoleMessage);
     webview.removeEventListener('did-navigate', this.handleDidNavigate);
+    webview.removeEventListener(
+      'page-title-updated',
+      this.handlePageTitleUpdated,
+    );
     webview.removeEventListener('did-stop-loading', this.refocusWebview);
   }
 

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -51,6 +51,8 @@ export default class Service {
 
   @observable dialogTitle: string = '';
 
+  @observable pageTitle: string = '';
+
   @observable order: number = DEFAULT_SERVICE_ORDER;
 
   @observable isEnabled: boolean = DEFAULT_SERVICE_SETTINGS.isEnabled;

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -140,6 +140,7 @@ export default class ServicesStore extends TypedStore {
 
     this.registerReactions([
       this._focusServiceReaction.bind(this),
+      this._updateWindowTitleReaction.bind(this),
       this._getUnreadMessageCountReaction.bind(this),
       this._mapActiveServiceToServiceModelReaction.bind(this),
       this._saveActiveService.bind(this),
@@ -660,6 +661,7 @@ export default class ServicesStore extends TypedStore {
   @action _setActive({ serviceId, keepActiveRoute = null }) {
     if (!keepActiveRoute) this.stores.router.push('/');
     const service = this.one(serviceId);
+    const wasActive = service.isActive;
 
     for (const s of this.all) {
       if (s.isActive) {
@@ -683,7 +685,9 @@ export default class ServicesStore extends TypedStore {
     );
     this.lastUsedServices.unshift(serviceId);
 
-    this._focusActiveService();
+    // A different active service is focused by _focusServiceReaction.
+    // Clicking the current service still needs to restore keyboard focus.
+    if (wasActive) this._focusActiveService();
   }
 
   @action _blurActive() {
@@ -752,6 +756,8 @@ export default class ServicesStore extends TypedStore {
     service.webview = null;
     // eslint-disable-next-line no-param-reassign
     service.isAttached = false;
+    // eslint-disable-next-line no-param-reassign
+    service.pageTitle = '';
   }
 
   @action _focusService({ serviceId }) {
@@ -768,10 +774,7 @@ export default class ServicesStore extends TypedStore {
       // TODO: add checks to not focus service when router path is /settings or /auth
       const service = this.active;
       if (service) {
-        if (service._webview) {
-          document.title = `Ferdium - ${service.name} ${
-            service.dialogTitle ? ` - ${service.dialogTitle}` : ''
-          } ${service._webview ? `- ${service._webview.getTitle()}` : ''}`;
+        if (service.webview) {
           this._focusService({ serviceId: service.id });
           if (this.stores.settings.app.splitMode && !focusEvent) {
             setTimeout(() => {
@@ -1264,12 +1267,18 @@ export default class ServicesStore extends TypedStore {
 
   // Reactions
   _focusServiceReaction() {
+    if (this.active) {
+      // The action is untracked: title/settings changes must not refocus a page.
+      this._focusActiveService();
+    }
+  }
+
+  _updateWindowTitleReaction() {
     const service = this.active;
     if (service) {
-      this.actions.service.focusService({ serviceId: service.id });
-      document.title = `Ferdium - ${service.name} ${
+      document.title = `Ferdium - ${service.name}${
         service.dialogTitle ? ` - ${service.dialogTitle}` : ''
-      } ${service._webview ? `- ${service._webview.getTitle()}` : ''}`;
+      }${service.pageTitle ? ` - ${service.pageTitle}` : ''}`;
     } else {
       debug('No service is active');
     }


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the Contributing Guidelines.
- [x] I agree to follow the Code of Conduct.

#### Description of Change

- Cache each service's page title, refresh it on navigation and `page-title-updated`, and clear it when its webview detaches.
- Update the window title in a separate reaction. Background services no longer replace the active service's window title.
- Focus a newly selected service once. Preserve current-tab clicks, window refocusing, split-view scrolling, Todos, and load-completion focus after hibernation.
- Remove the delayed load-completion title query that could run after a different service became active or the original webview detached.

#### Motivation and Context

An isolated execution of the existing ServicesStore/MobX switching path showed two synchronous `getTitle()` calls and two blur/focus cycles for one warm service switch. The explicit activation handler and the active-service reaction both performed this work. The same reaction also refocused a service when its name or dialog title changed.

With this change, the same diagnostic reports **0 title queries and 1 blur/focus cycle per warm switch**. Title-only changes cause no focus calls. Navigation still seeds the cached title with `getTitle()`; it is no longer queried during ordinary activation.

This targets Ferdium's host-side overhead, not Slack/WhatsApp rendering. Hibernation settings and memory-saving behavior are unchanged; waking an unloaded service still requires loading its page.

#### Validation

- Node 24.18.1 / pnpm 11.20.0.
- `pnpm typecheck`.
- Targeted ESLint (zero warnings), Biome, Prettier, and `git diff --check`.
- Existing Jest suite: **14 suites passed; 119 tests passed, 2 existing skips**.
- Source build: `preval-build-info-cli` followed by `node esbuild.mjs`.
- React Doctor: no findings on the changed files.
- Additional inline diagnostics using actual store/component methods and MobX, with browser APIs mocked: warm switching, same-tab clicks, window refocus, foreground/background title changes, split scrolling, hibernation wake/load focus, listener replacement/removal, detach cleanup, and Todos focus.

No new or modified test files. No packaged-app GUI run or real-world latency measurement is claimed. Native verification should exercise rapid switching, keyboard focus, split view, and hibernation on each desktop platform.

#### Checklist

- [x] My pull request is properly named.
- [x] Targeted code-style checks pass (rather than repository-wide autofixing).
- [x] `pnpm test` passes.
- [ ] Packaged application manually previewed.

#### Release Notes

Reduce redundant focus and title work when switching services, and prevent background pages from overwriting the active window title.

