### PR TITLE
perf: avoid layout and theme rebuilds on service switches

### DIFF
--- a/src/@types/stores.types.ts
+++ b/src/@types/stores.types.ts
@@ -113,6 +113,7 @@ export interface AppStore extends TypedStore {
   reloadAfterResume: boolean;
   reloadAfterResumeTime: number;
   searchEngine: string;
+  showDisabledServices: boolean;
   translatorEngine: string;
   translatorLanguage: string;
   spellcheckerLanguage: string;

--- a/src/containers/layout/AppLayoutContainer.tsx
+++ b/src/containers/layout/AppLayoutContainer.tsx
@@ -3,17 +3,12 @@ import { Component, type ReactElement } from 'react';
 import { ThemeProvider } from 'react-jss';
 import { Outlet } from 'react-router-dom';
 
-import {
-  ThemeProvider as MUIThemeProvider,
-  createTheme,
-} from '@mui/material/styles';
-import tinycolor from 'tinycolor2';
+import { ThemeProvider as MUIThemeProvider } from '@mui/material/styles';
 import type { StoresProps } from '../../@types/ferdium-components.types';
 import AppLayout from '../../components/layout/AppLayout';
 import Sidebar from '../../components/layout/Sidebar';
 import Services from '../../components/services/content/Services';
 import AppLoader from '../../components/ui/AppLoader';
-import { DEFAULT_ACCENT_COLOR } from '../../config';
 import { workspaceStore } from '../../features/workspaces';
 import WorkspaceDrawer from '../../features/workspaces/components/WorkspaceDrawer';
 
@@ -52,33 +47,6 @@ class AppLayoutContainer extends Component<IProps> {
       hibernate,
       awake,
     } = this.props.actions.service;
-
-    // This is a workaround to fix theming on MUI components when the settings are poorly set
-    let { accentColor } = settings.app;
-    accentColor = tinycolor(accentColor).isValid()
-      ? accentColor
-      : DEFAULT_ACCENT_COLOR;
-    // ---
-
-    // This is a workaround to fix theming on MUI components
-    const themeMUIDark = createTheme({
-      palette: {
-        mode: 'dark',
-        primary: {
-          main: accentColor,
-        },
-      },
-    });
-
-    const themeMUILight = createTheme({
-      palette: {
-        mode: 'light',
-        primary: {
-          main: accentColor,
-        },
-      },
-    });
-    // ---
 
     const { retryRequiredRequests } = this.props.actions.requests;
 
@@ -122,8 +90,8 @@ class AppLayoutContainer extends Component<IProps> {
       <Sidebar
         services={services.allDisplayed}
         setActive={setActive}
-        isAppMuted={settings.all.app.isAppMuted}
-        isMenuCollapsed={settings.all.app.isMenuCollapsed}
+        isAppMuted={settings.app.isAppMuted}
+        isMenuCollapsed={settings.app.isMenuCollapsed}
         openSettings={openSettings}
         openDownloads={openDownloads}
         closeSettings={closeSettings}
@@ -145,9 +113,9 @@ class AppLayoutContainer extends Component<IProps> {
         isWorkspaceDrawerOpen={workspaceStore.isWorkspaceDrawerOpen}
         showServicesUpdatedInfoBar={ui.showServicesUpdatedInfoBar}
         showMessageBadgeWhenMutedSetting={
-          settings.all.app.showMessageBadgeWhenMuted
+          settings.app.showMessageBadgeWhenMuted
         }
-        showServiceNameSetting={settings.all.app.showServiceName}
+        showServiceNameSetting={settings.app.showServiceName}
         showMessageBadgesEvenWhenMuted={ui.showMessageBadgesEvenWhenMuted}
         isTodosServiceActive={services.isTodosServiceActive || false}
       />
@@ -170,9 +138,7 @@ class AppLayoutContainer extends Component<IProps> {
 
     return (
       // TODO: Using 2 ThemeProviders is not ideal, but it's a workaround for now
-      <MUIThemeProvider
-        theme={settings.app.darkMode ? themeMUIDark : themeMUILight}
-      >
+      <MUIThemeProvider theme={ui.muiTheme}>
         <ThemeProvider theme={ui.theme}>
           <AppLayout
             settings={settings}

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -348,7 +348,7 @@ export default class ServicesStore extends TypedStore {
   }
 
   @computed get allDisplayed(): Service[] {
-    const services = this.stores.settings.all.app.showDisabledServices
+    const services = this.stores.settings.app.showDisabledServices
       ? this.all
       : this.enabled;
     return workspaceStore.filterServicesByActiveWorkspace(services);
@@ -356,7 +356,7 @@ export default class ServicesStore extends TypedStore {
 
   // This is just used to avoid unnecessary rerendering of resource-heavy webviews
   @computed get allDisplayedUnordered() {
-    const { showDisabledServices } = this.stores.settings.all.app;
+    const { showDisabledServices } = this.stores.settings.app;
     const { keepAllWorkspacesLoaded } = this.stores.workspaces.settings;
     const services = this.allServicesRequest.execute().result || [];
     const filteredServices = showDisabledServices

--- a/src/stores/UIStore.ts
+++ b/src/stores/UIStore.ts
@@ -1,9 +1,12 @@
 import { nativeTheme } from '@electron/remote';
+import { createTheme } from '@mui/material/styles';
 import { action, computed, makeObservable, observable, reaction } from 'mobx';
+import tinycolor from 'tinycolor2';
 
 import type { Stores } from '../@types/stores.types';
 import type { Actions } from '../actions/lib/actions';
 import type { ApiInterface } from '../api';
+import { DEFAULT_ACCENT_COLOR } from '../config';
 import { type Theme, ThemeType, theme } from '../themes';
 import TypedStore from './lib/TypedStore';
 
@@ -95,6 +98,21 @@ export default class UIStore extends TypedStore {
         : ThemeType.default;
     const { accentColor } = this.stores.settings.app;
     return theme(themeId, accentColor);
+  }
+
+  @computed get muiTheme() {
+    const { accentColor, darkMode } = this.stores.settings.app;
+
+    return createTheme({
+      palette: {
+        mode: darkMode ? 'dark' : 'light',
+        primary: {
+          main: tinycolor(accentColor).isValid()
+            ? accentColor
+            : DEFAULT_ACCENT_COLOR,
+        },
+      },
+    });
   }
 
   // Actions


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the Contributing Guidelines.
- [x] I agree to follow the Code of Conduct.

#### Description of Change

- Move MUI theme creation into a cached MobX computed on UIStore. Create only the selected theme and preserve its identity until dark mode or accent color changes.
- Preserve the existing dark-mode selection and invalid-accent fallback.
- Read app settings directly in AppLayoutContainer and the displayed-service computed getters. Persisting the active service no longer invalidates these consumers through the aggregate `settings.all` object.
- Add the existing `showDisabledServices` setting to the legacy store type interface.

#### Motivation and Context

Every service switch persists `activeService`. Previously, this invalidated the aggregate settings object, rebuilt displayed-service arrays, and rerendered AppLayoutContainer. Each render then created both light and dark MUI themes, changing the provider value even though appearance settings were unchanged.

For an ordinary warm service switch within one workspace, an isolated source/MobX diagnostic reports:

| Host-side work | Before | After |
| --- | ---: | ---: |
| AppLayoutContainer render executions | 1 | 0 |
| MUI theme creations | 2 | 0 |

Theme identity also remains stable when unrelated settings cause a layout update. Actual appearance changes still rebuild the theme.

These are isolated work counts with browser APIs mocked, not a packaged-app frame-time benchmark. This PR is independent of #2530, which removes duplicate focus/title work. Hibernation preferences and service loading behavior are unchanged.

#### Validation

- Node 24.18.1 / pnpm 11.20.0.
- `pnpm typecheck`.
- Targeted ESLint (zero warnings), Biome, Prettier, and `git diff --check`.
- Existing Jest suite: **14 suites passed; 119 tests passed, 2 existing skips**.
- Source build: `preval-build-info-cli` followed by `node esbuild.mjs`.
- React Doctor: no findings on changed files.
- Additional inline diagnostics using actual SettingsStore, ServicesStore, UIStore, layout render code, MobX, and MUI theme creation: stable themes/layout on warm switches, unrelated settings changes, dark-mode changes, valid/invalid accents, and service enable/disable visibility.

No new or modified test files. Packaged GUI testing and real-world latency profiling remain to be done.

#### Checklist

- [x] My pull request is properly named.
- [x] Targeted code-style checks pass (rather than repository-wide autofixing).
- [x] `pnpm test` passes.
- [ ] Packaged application manually previewed.

#### Release Notes

Avoid unnecessary app-layout rendering and theme rebuilding when switching services.

