### PR TITLE
fix: recover failed service loads automatically and on tab activation

### DIFF
--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -17,6 +17,24 @@ import UserAgent from './UserAgent';
 
 const debug = require('../preload-safe-debug')('Ferdium:Service');
 
+const LOAD_RETRY_DELAYS = [10_000, 30_000, 60_000];
+// Chromium net errors for transient network failures. Certificate, permission,
+// authentication and blocked-request errors still require user intervention.
+const RETRYABLE_LOAD_ERRORS = new Set([
+  -7, // TIMED_OUT
+  -21, // NETWORK_CHANGED
+  -100, // CONNECTION_CLOSED
+  -101, // CONNECTION_RESET
+  -102, // CONNECTION_REFUSED
+  -104, // CONNECTION_FAILED
+  -105, // NAME_NOT_RESOLVED
+  -106, // INTERNET_DISCONNECTED
+  -109, // ADDRESS_UNREACHABLE
+  -118, // CONNECTION_TIMED_OUT
+  -137, // NAME_RESOLUTION_FAILED
+  -352, // HTTP2_PING_FAILED
+]);
+
 // Global registry for active partitions
 // This is needed to prevent events of the same partition from being registered multiple times (when using custom sandboxes)
 const activePartitions = new Set<string>();
@@ -106,6 +124,19 @@ export default class Service {
   @observable isError: boolean = false;
 
   @observable errorMessage: string = '';
+
+  private loadErrorCode: number | null = null;
+
+  private loadFailedAt: number = 0;
+
+  private loadRetryAttempts: number = 0;
+
+  private lastLoadRetryAt: number | null = null;
+
+  // A failure after a real page committed must not discard that page's state.
+  private hasCommittedNavigation: boolean = false;
+
+  private retryingWebview: ElectronWebView | null = null;
 
   @observable isUsingCustomUrl: boolean = false;
 
@@ -256,10 +287,11 @@ export default class Service {
   }
 
   @action _didStartLoading(): void {
+    // Keep a failed load visible until a real main-frame navigation commits.
+    // Subframe activity and Chromium's error document must not clear it.
     this.hasCrashed = false;
     this.isLoading = true;
     this.isLoadingPage = true;
-    this.isError = false;
   }
 
   @action _didStopLoading(): void {
@@ -273,14 +305,88 @@ export default class Service {
 
     if (!this.isError) {
       this.isFirstLoad = false;
+      this.loadRetryAttempts = 0;
+      this.lastLoadRetryAt = null;
     }
   }
 
-  @action _didFailLoad(event: { errorDescription: string }): void {
+  @action _didNavigate(): void {
+    this.hasCommittedNavigation = true;
     this.isError = false;
+    this.errorMessage = '';
+    this.loadErrorCode = null;
+  }
+
+  @action _didFailLoad(event: {
+    errorCode: number;
+    errorDescription: string;
+  }): void {
+    this.isError = true;
+    this.loadErrorCode = event.errorCode;
+    this.loadFailedAt = Date.now();
     this.errorMessage = event.errorDescription;
     this.isLoading = false;
     this.isLoadingPage = false;
+  }
+
+  @action retryFailedLoad(isOnline: boolean, onActivation = false): void {
+    const { webview } = this;
+    if (
+      !this.isError ||
+      this.hasCommittedNavigation ||
+      this.loadErrorCode === null ||
+      !RETRYABLE_LOAD_ERRORS.has(this.loadErrorCode) ||
+      !isOnline ||
+      !this.isEnabled ||
+      !this.isAttached ||
+      !webview ||
+      this.retryingWebview === webview ||
+      this.isLoading ||
+      this.isHibernating ||
+      this.isMediaPlaying ||
+      this.hasCrashed ||
+      this.isServiceAccessRestricted ||
+      this.isTodosService
+    ) {
+      return;
+    }
+
+    const now = Date.now();
+    const delay = LOAD_RETRY_DELAYS[this.loadRetryAttempts];
+    if (
+      (this.lastLoadRetryAt !== null &&
+        now - this.lastLoadRetryAt < LOAD_RETRY_DELAYS[0]) ||
+      (!onActivation &&
+        (delay === undefined ||
+          now - Math.max(this.loadFailedAt, this.lastLoadRetryAt ?? 0) < delay))
+    ) {
+      return;
+    }
+
+    this.lastLoadRetryAt = now;
+    this.loadRetryAttempts = Math.min(
+      this.loadRetryAttempts + 1,
+      LOAD_RETRY_DELAYS.length,
+    );
+    // Mark the request in flight before calling Electron; tab activation and
+    // maintenance can otherwise start overlapping navigations.
+    this.retryingWebview = webview;
+    try {
+      // Open the configured service URL with a fresh GET,
+      // rather than replaying a failed form submission or authentication URL.
+      Promise.resolve(webview.loadURL(this.url))
+        .catch(() => {
+          // did-fail-load records the error. Do not let a stale rejection change
+          // the state of a newer navigation or a replacement webview.
+          debug('Service load retry failed', this.id);
+        })
+        .finally(() => {
+          if (this.retryingWebview === webview) this.retryingWebview = null;
+        });
+    } catch {
+      this.retryingWebview = null;
+      debug('Unable to start service load retry', this.id);
+    }
   }
 
   @action _hasCrashed(): void {
@@ -536,33 +642,37 @@ export default class Service {
       },
     );
 
+    this.webview.addEventListener('did-start-navigation', event => {
+      if (this.webview === webview && event.isMainFrame && !event.isInPlace) {
+        this.hasCommittedNavigation = false;
+      }
+    });
+
     this.webview.addEventListener('did-start-loading', event => {
+      if (this.webview !== webview) return;
       debug('Did start load', this.name, event);
 
       this._didStartLoading();
     });
 
     this.webview.addEventListener('did-stop-loading', event => {
+      if (this.webview !== webview) return;
       debug('Did stop load', this.name, event);
 
       this._didStopLoading();
     });
 
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const didLoad = () => {
-      this._didLoad();
-    };
-
-    this.webview.addEventListener('did-frame-finish-load', didLoad.bind(this));
-    this.webview.addEventListener('did-navigate', didLoad.bind(this));
+    this.webview.addEventListener('did-frame-finish-load', event => {
+      if (this.webview === webview && event.isMainFrame) this._didLoad();
+    });
+    this.webview.addEventListener('did-navigate', () => {
+      if (this.webview === webview) this._didNavigate();
+    });
 
     this.webview.addEventListener('did-fail-load', event => {
+      if (this.webview !== webview) return;
       debug('Service failed to load', this.name, event);
-      if (
-        event.isMainFrame &&
-        event.errorCode !== -21 &&
-        event.errorCode !== -3
-      ) {
+      if (event.isMainFrame && event.errorCode !== -3) {
         this._didFailLoad(event);
       }
     });

--- a/src/stores/ServicesStore.ts
+++ b/src/stores/ServicesStore.ts
@@ -297,6 +297,8 @@ export default class ServicesStore extends TypedStore {
         }
       }
 
+      service.retryFailedLoad(this.stores.app.isOnline);
+
       if (
         service.lastPoll &&
         service.lastPoll - service.lastPollAnswer > ms('1m')
@@ -671,6 +673,7 @@ export default class ServicesStore extends TypedStore {
     }
     this._setIsActive(service, true);
     this._awake({ serviceId: service.id });
+    service.retryFailedLoad(this.stores.app.isOnline, true);
 
     if (
       this.isTodosServiceActive &&


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the Contributing Guidelines.
- [x] I agree to follow the Code of Conduct.

#### Description of Change

Recover transient **main-frame page-load failures** without requiring the user to keep pressing Cmd/Ctrl+R.

- Set `isError` when a main-frame load fails, enabling the existing error details and Reload button instead of silently showing a blank page.
- Retain the error through loading activity and error-document completion. Clear it only when a real main-frame navigation commits; reset the retry budget only after that main frame finishes loading.
- Use the existing 10-second service-maintenance tick for at most three automatic retries, with minimum delays of 10, 30 and 60 seconds after successive failures. No additional per-service timers or healthy-page IPC probes.
- Retry an eligible failed service when it is selected, including after the automatic budget is exhausted. A 10-second per-service cooldown and an in-flight guard prevent rapid switching from causing overlapping/repeated loads. Selecting a tab does not reset the automatic budget.
- Pause recovery while offline and skip detached, disabled, hibernating, loading, crashed, access-restricted, media-playing and Todos services.
- Allowlist transient Chromium network errors (including `ERR_NETWORK_CHANGED`, previously ignored). Certificate, permission, authentication, blocked-request and other unclassified failures remain visible for manual intervention. Canceled navigations and subframe failures do not trigger recovery.
- Do not automatically reload a document that already committed and subsequently reports a loading failure: it may still contain usable state or unsaved work.
- Reopen the configured service URL using a fresh GET. Do not replay failed POST bodies or authentication callback URLs.
- Ignore lifecycle events from replaced webviews and consume retry promise rejections without letting stale completions alter newer navigation state.

#### Motivation and Context

A failed service navigation can leave Chromium's blank internal error document while Ferdium's `_didFailLoad` explicitly sets `isError = false`. Neither service activation nor maintenance retries that navigation. A normal service reload can recover it, but currently requires repeated manual intervention.

This PR handles that specific failure mode. It does not claim to prevent upstream website failures or recover arbitrary JavaScript deadlocks. It does not change the separate recipe-heartbeat watchdog, renderer crash recovery, or recipe scripts.

Electron's [navigation event contract](https://www.electronjs.org/docs/latest/api/webview-tag#event-did-fail-load) and [43.3.0 navigation implementation](https://github.com/electron/electron/blob/v43.3.0/shell/browser/api/electron_api_web_contents.cc#L2356) distinguish error-document commits from successful `did-navigate` events. This change uses that distinction rather than treating any frame completion as recovery.

#### Validation

- `pnpm typecheck`
- Targeted ESLint (zero warnings), Biome and Prettier checks; `git diff --check`
- Existing Jest suite: **14 suites passed, 119 tests passed, 2 existing skips**
- Inline actual-source diagnostics with real MobX and mocked Electron events/clock: **49 scenarios passed**, covering backoff/cap/cooldown, activation and maintenance integration, offline recovery, main/subframe ordering, successful recovery, stale webviews, in-flight requests, synchronous throws/asynchronous rejections, and the safety guards.
- Source build: `pnpm exec preval-build-info-cli` followed by `node esbuild.mjs`
- React Doctor: no findings in the changed files.
- No test files added or modified. The patched packaged desktop app has not been exercised against logged-in third-party services; this is not a claim of live end-to-end verification.

Suggested desktop validation: cause a service's initial/main-frame navigation to fail with a transient network error; restore connectivity; verify bounded recovery and the Reload fallback. Repeat with automatic attempts exhausted and select the failed service. Confirm healthy tabs, subframe-only failures, certificate failures, and media-playing services are not automatically reloaded.

#### Release Notes

Retry transient service loading failures automatically and when returning to the affected tab, with bounded retries and visible error details.