### PR TITLE
fix: stringify URL objects passed to window.open in services

### DIFF
--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -39,6 +39,7 @@ import {
   getSpellcheckerLocaleByFuzzyIdentifier,
   switchDict,
 } from './spellchecker';
+import { windowOpenShim } from './windowOpenShim';
 
 import type { AppStore } from '../@types/stores.types';
 import { DEFAULT_APP_SETTINGS } from '../config';
@@ -157,7 +158,7 @@ if (process.platform === 'linux') {
 
 ipcRenderer.sendToHost(
   'inject-js-unsafe',
-  'window.open = window.ferdium.open;',
+  windowOpenShim,
   notificationsClassDefinition,
   screenShareJs,
 );

--- a/src/webview/windowOpenShim.ts
+++ b/src/webview/windowOpenShim.ts
@@ -1,0 +1,7 @@
+// Source of the window.open replacement injected into a service's page
+// world. window.ferdium.open is a contextBridge function, so a URL object
+// passed to window.open would cross the bridge as {} and Chromium would
+// then open "[object Object]"; stringify it here, in the page world,
+// before it reaches the bridge. null/undefined are left as they are.
+export const windowOpenShim =
+  'window.open = (url, frameName, features) => window.ferdium.open(url == null ? url : String(url), frameName, features);';

--- a/test/webview/windowOpenShim.test.ts
+++ b/test/webview/windowOpenShim.test.ts
@@ -1,0 +1,45 @@
+import { runInNewContext } from 'node:vm';
+
+import { windowOpenShim } from '../../src/webview/windowOpenShim';
+
+function installShim() {
+  const open = jest.fn();
+  const window: {
+    ferdium: { open: jest.Mock };
+    open?: (...args: unknown[]) => unknown;
+  } = { ferdium: { open } };
+  runInNewContext(`"use strict"; (() => { ${windowOpenShim} })();`, { window });
+  return { open, windowOpen: window.open! };
+}
+
+describe('windowOpenShim', () => {
+  it('stringifies a URL object before it reaches ferdium.open', () => {
+    const { open, windowOpen } = installShim();
+    windowOpen(new URL('https://example.com/path?x=1'), '_blank', 'noopener');
+    expect(open).toHaveBeenCalledWith(
+      'https://example.com/path?x=1',
+      '_blank',
+      'noopener',
+    );
+  });
+
+  it('passes a string url through unchanged', () => {
+    const { open, windowOpen } = installShim();
+    windowOpen('https://example.com/', '_blank');
+    expect(open).toHaveBeenCalledWith(
+      'https://example.com/',
+      '_blank',
+      undefined,
+    );
+  });
+
+  it('leaves undefined and null urls untouched', () => {
+    const { open, windowOpen } = installShim();
+    windowOpen();
+    windowOpen(null);
+    expect(open.mock.calls).toStrictEqual([
+      [undefined, undefined, undefined],
+      [null, undefined, undefined],
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Ferdium replaces `window.open` inside every service with `window.ferdium.open`, a function exposed through `contextBridge`. When a web app passes a `URL` object instead of a string, the bridge serializes it as `{}` (a `URL` has no own enumerable properties), so the original `window.open` receives `{}`, Chromium stringifies it to `[object Object]`, and the link opens as e.g. `https://web.telegram.org/a/[object Object]`.

The changes:

* Move the injected `window.open` replacement into `src/webview/windowOpenShim.ts`. The shim converts the URL to a string in the page world before it crosses the bridge, and leaves `null`/`undefined` untouched so the existing `!url` branch (used by services that set `location.href` on the returned window) keeps working.
* Add `test/webview/windowOpenShim.test.ts`, which evaluates the shim source in an isolated context and checks a `URL` object, a plain string, and `undefined`/`null`.

#### Motivation and Context

Fixes #2209.

Telegram Web A opens external links with `window.open(new URL(...), '_blank', 'noopener')`, so every link clicked in the Telegram service opens `web.telegram.org/a/[object Object]` in the browser. Right-click → Open Link works because that path never runs the page's `window.open`. The fix is in the shared injection rather than the Telegram recipe because any service that passes a `URL` object hits the same bridge serialization.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes

Fixed links opening as `[object Object]` when a service (e.g. Telegram) passes a URL object to `window.open`.
