### PR TITLE
feat: add support for autofill service logins on macOS

### DIFF
--- a/src/webview/contextMenu.ts
+++ b/src/webview/contextMenu.ts
@@ -15,9 +15,9 @@ export default async function setupContextMenu(
 ) {
   const contextMenuBuilder = new ContextMenuBuilder(webContents);
 
-  webContents.on('context-menu', (_e, props) => {
-    // TODO?: e.preventDefault();
-    contextMenuBuilder.showPopupMenu(
+  webContents.on('context-menu', async (_e, props) => {
+    // The originating frame enables native macOS AutoFill in Electron menus.
+    const menu = await contextMenuBuilder.buildMenuForElement(
       {
         ...props,
         searchEngine: getSearchEngine(),
@@ -31,5 +31,13 @@ export default async function setupContextMenu(
       getDefaultSpellcheckerLanguage(),
       getSpellcheckerLanguage(),
     );
+
+    if (!menu) return;
+
+    if (props.frame) {
+      menu.popup({ frame: props.frame });
+    } else {
+      menu.popup();
+    }
   });
 }

--- a/test/webview/contextMenu.test.ts
+++ b/test/webview/contextMenu.test.ts
@@ -1,0 +1,79 @@
+type ContextMenuHandler = (
+  event: unknown,
+  props: Electron.ContextMenuParams,
+) => Promise<void>;
+
+describe('service context menu', () => {
+  let contextMenuHandler!: ContextMenuHandler;
+  let buildMenuForElement!: jest.Mock;
+  let popup!: jest.Mock;
+  let setupContextMenu!: typeof import('../../src/webview/contextMenu').default;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    popup = jest.fn();
+    buildMenuForElement = jest.fn().mockResolvedValue({ popup });
+
+    const on = jest.fn((eventName: string, handler: ContextMenuHandler) => {
+      if (eventName === 'context-menu') {
+        contextMenuHandler = handler;
+      }
+    });
+
+    jest.doMock('@electron/remote', () => ({
+      getCurrentWebContents: () => ({ on }),
+    }));
+    jest.doMock('../../src/webview/contextMenuBuilder', () => ({
+      ContextMenuBuilder: jest.fn().mockImplementation(() => ({
+        buildMenuForElement,
+      })),
+    }));
+
+    setupContextMenu = jest.requireActual<
+      typeof import('../../src/webview/contextMenu')
+    >('../../src/webview/contextMenu').default;
+  });
+
+  afterEach(() => {
+    jest.dontMock('@electron/remote');
+    jest.dontMock('../../src/webview/contextMenuBuilder');
+  });
+
+  async function initializeContextMenu() {
+    await setupContextMenu(
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+    );
+  }
+
+  it('associates the popup with the frame that invoked the context menu', async () => {
+    await initializeContextMenu();
+    const frame = {} as Electron.WebFrameMain;
+
+    await contextMenuHandler({}, {
+      frame,
+      formControlType: 'input-password',
+      isEditable: true,
+    } as unknown as Electron.ContextMenuParams);
+
+    expect(buildMenuForElement.mock.calls[0][0].frame).toBe(frame);
+    expect(popup).toHaveBeenCalledWith({ frame });
+  });
+
+  it('falls back safely when Electron does not provide a frame', async () => {
+    await initializeContextMenu();
+
+    await contextMenuHandler({}, {
+      frame: null,
+    } as unknown as Electron.ContextMenuParams);
+
+    expect(popup).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.
#### Pre-flight Checklist

#### Description of Change

Enable native macOS AutoFill support for login fields inside Ferdium service webviews.

When opening a service context menu, Ferdium now passes the originating Electron `WebFrameMain` to `Menu.popup()`. Electron requires the target frame to be provided for native macOS AutoFill functionality to be available in editable web content.

This allows password managers exposed through macOS AutoFill, such as Apple Passwords and compatible third-party providers, to appear in the native context menu for service login fields while keeping authentication (for example, Touch ID) handled by macOS or the password manager.

The existing context menu behavior and contents remain unchanged. If no frame is available, the context menu falls back to the existing popup behavior.

Tests have been added to verify that:

* The originating service frame is passed to the native context menu popup.
* The existing behavior is preserved when no frame is available.

#### Motivation and Context

Service sessions can expire and require users to sign in again. On macOS, users currently need to manually copy and paste credentials from their password manager into Ferdium.

Providing the originating web frame to Electron's native context menu enables macOS AutoFill within Ferdium's service webviews without introducing password-manager-specific integrations or handling credentials directly in Ferdium.

Fixes #2549

#### Checklist

* [x] My pull request is properly named
* [x] The changes respect the code style of the project (`pnpm prepare-code`)
* [x] `pnpm test` passes
* [x] I tested/previewed my changes locally

#### Release Notes

Enable native macOS AutoFill for login fields inside Ferdium services.