### PR TITLE
fix: keep service popups usable so Slack huddle windows open and stay visible

### DIFF
--- a/src/electron/popupWindowOptions.ts
+++ b/src/electron/popupWindowOptions.ts
@@ -1,0 +1,88 @@
+import type { BrowserWindowConstructorOptions } from 'electron';
+
+// Chromium hands the raw window.open() features string to Electron, which
+// turns every `key=value` pair into a BrowserWindow constructor option
+// (electron/lib/browser/parse-features-string.ts). Browsers only honour a
+// handful of size and position features, but pages that also run inside
+// Electron-based desktop apps pass Electron options too. Slack, for example,
+// opens its huddle window with `show=no,alwaysOnTop=yes,fullscreenable=no,...`
+// and shows the window later through its own desktop bridge; without that
+// bridge the popup simply stays invisible (ferdium-app#788). These helpers
+// normalise the options so a popup opened by a service always behaves like a
+// popup opened in a browser.
+
+export const parseWindowFeatures = (
+  features = '',
+): Record<string, string | undefined> => {
+  const parsed: Record<string, string | undefined> = {};
+  for (const pair of features.split(',')) {
+    const [key, value] = pair.split('=').map(part => part.trim());
+    if (key) {
+      parsed[key] = value;
+    }
+  }
+  return parsed;
+};
+
+const isDisabled = (value: string | undefined): boolean =>
+  value !== undefined && /^(?:no|0|false)$/i.test(value);
+
+const parseCoordinate = (value: string | undefined): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+// Popups stay resizable unless the page explicitly opts out. Electron 38+
+// made every window.open() popup resizable to match the WHATWG spec; Slack
+// opens its huddle / screen-share window without asking for `resizable`, and
+// a fixed-size window is useless for a shared screen.
+export const windowOpenFeaturesAllowResizable = (features = ''): boolean =>
+  !isDisabled(parseWindowFeatures(features).resizable);
+
+export const popupWindowOptions = (
+  features: string | undefined,
+  isPositionOnScreen: (position: { x: number; y: number }) => boolean,
+): BrowserWindowConstructorOptions => {
+  const parsed = parseWindowFeatures(features);
+
+  const options: BrowserWindowConstructorOptions = {
+    // Options a web page must not be able to control. Electron spreads these
+    // over the parsed features, so every one of them has to be set explicitly.
+    show: true,
+    alwaysOnTop: false,
+    frame: true,
+    transparent: false,
+    skipTaskbar: false,
+    focusable: true,
+    kiosk: false,
+    fullscreen: false,
+    simpleFullscreen: false,
+    modal: false,
+    opacity: 1,
+    closable: true,
+    minimizable: true,
+    maximizable: true,
+    movable: true,
+    enableLargerThanScreen: false,
+    hasShadow: true,
+    titleBarStyle: 'default',
+    // Let the user maximize / fullscreen e.g. a shared screen even when the
+    // page asked for `fullscreenable=no`.
+    fullscreenable: true,
+    resizable: !isDisabled(parsed.resizable),
+  };
+
+  // Pages remember where their popup was last time; if that position is not
+  // on a connected display any more, let Electron center the window instead.
+  const x = parseCoordinate(parsed.x ?? parsed.left);
+  const y = parseCoordinate(parsed.y ?? parsed.top);
+  if (x !== undefined && y !== undefined && !isPositionOnScreen({ x, y })) {
+    options.x = undefined;
+    options.y = undefined;
+  }
+
+  return options;
+};

--- a/src/electron/popupWindowOptions.ts
+++ b/src/electron/popupWindowOptions.ts
@@ -24,9 +24,6 @@ export const parseWindowFeatures = (
   return parsed;
 };
 
-const isDisabled = (value: string | undefined): boolean =>
-  value !== undefined && /^(?:no|0|false)$/i.test(value);
-
 const parseCoordinate = (value: string | undefined): number | undefined => {
   if (value === undefined) {
     return undefined;
@@ -34,13 +31,6 @@ const parseCoordinate = (value: string | undefined): number | undefined => {
   const parsed = Number.parseInt(value, 10);
   return Number.isNaN(parsed) ? undefined : parsed;
 };
-
-// Popups stay resizable unless the page explicitly opts out. Electron 38+
-// made every window.open() popup resizable to match the WHATWG spec; Slack
-// opens its huddle / screen-share window without asking for `resizable`, and
-// a fixed-size window is useless for a shared screen.
-export const windowOpenFeaturesAllowResizable = (features = ''): boolean =>
-  !isDisabled(parseWindowFeatures(features).resizable);
 
 export const popupWindowOptions = (
   features: string | undefined,
@@ -72,7 +62,6 @@ export const popupWindowOptions = (
     // Let the user maximize / fullscreen e.g. a shared screen even when the
     // page asked for `fullscreenable=no`.
     fullscreenable: true,
-    resizable: !isDisabled(parsed.resizable),
   };
 
   // Pages remember where their popup was last time; if that position is not

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import handleDeepLink, { getDeepLinkFromArgs } from './electron/deepLinking';
 import './electron/exception';
 // eslint-disable-next-line import/no-cycle
 import ipcApi from './electron/ipc-api';
+import { popupWindowOptions } from './electron/popupWindowOptions';
 import isPositionValid from './electron/windowUtils';
 import { mainIpcHandler as basicAuthHandler } from './features/basicAuth';
 import DBus from './lib/DBus';
@@ -224,9 +225,6 @@ const webRTCIPHandlingPolicy = retrieveSettingValue(
   | 'default_public_interface_only'
   | 'default_public_and_private_interfaces';
 
-const windowOpenFeaturesRequestResizable = (features = ''): boolean =>
-  /(?:^|,)\s*resizable(?:=(?:yes|1|true))?(?:,|$)/i.test(features);
-
 const createWindow = () => {
   // Remember window size
   const mainWindowState = windowStateKeeper({
@@ -352,18 +350,26 @@ const createWindow = () => {
       }
 
       contents.setWindowOpenHandler(({ url, disposition, features }) => {
-        // OAuth popups (Google, Microsoft, etc.) are opened via window.open()
-        // and need window.opener preserved so the parent can receive the
-        // postMessage callback that completes the flow. Allow them as a child
-        // BrowserWindow that inherits the service partition.
+        // window.open() calls that ask for a window (a target name or window
+        // features) arrive with the 'new-window' disposition. OAuth popups
+        // (Google, Microsoft, etc.) need window.opener preserved so the parent
+        // receives the postMessage callback that completes the flow, and Slack
+        // renders its huddle / screen-share window into the popup's document
+        // from the opener. Both need a real popup on the service's session,
+        // and the page keeps the genuine WindowProxy (see windowOpenShim.ts).
+        // The popup is a standalone window rather than a child of the main
+        // window so it can be moved to another display, maximized or put in
+        // fullscreen, and stays visible while Ferdium is hidden or minimized.
+        // popupWindowOptions() keeps the page from controlling the window
+        // through Electron options in the features string (Slack asks for
+        // `show=no,alwaysOnTop=yes,...`, which would leave the huddle window
+        // invisible).
         if (disposition === 'new-window') {
           return {
             action: 'allow',
             outlivesOpener: false,
             overrideBrowserWindowOptions: {
-              parent: mainWindow,
-              fullscreenable: false,
-              resizable: windowOpenFeaturesRequestResizable(features),
+              ...popupWindowOptions(features, isPositionValid),
               webPreferences: isLinux
                 ? {
                     session: contents.session,
@@ -379,7 +385,8 @@ const createWindow = () => {
             },
           };
         }
-        // Regular link clicks → open in the user's default browser.
+        // Everything else (target=_blank links, window.open() without
+        // features) → open in the user's default browser.
         openExternalUrl(url);
         return { action: 'deny' };
       });
@@ -953,17 +960,23 @@ app.on('activate', () => {
   }
 });
 
+// Default handler for windows that are not service webviews, e.g. popups
+// opened by a service (the main window and the webviews install their own
+// handlers in createWindow). Links that would open a new tab go to the default
+// browser; nested window.open() popups are allowed.
 app.on('web-contents-created', (_createdEvent, contents) => {
-  contents.setWindowOpenHandler(({ disposition, features }) => {
+  contents.setWindowOpenHandler(({ url, disposition, features }) => {
     if (disposition === 'foreground-tab') {
+      openExternalUrl(url);
       return { action: 'deny' };
     }
 
     return {
       action: 'allow',
-      overrideBrowserWindowOptions: {
-        resizable: windowOpenFeaturesRequestResizable(features),
-      },
+      overrideBrowserWindowOptions: popupWindowOptions(
+        features,
+        isPositionValid,
+      ),
     };
   });
 });

--- a/src/webview/recipe.ts
+++ b/src/webview/recipe.ts
@@ -63,57 +63,19 @@ const sessionHandler = new SessionHandler();
 
 const notificationsHandler = new NotificationsHandler();
 
-// Patching window.open
-const originalWindowOpen = window.open;
-
-window.open = (url, frameName, features): WindowProxy | null => {
-  debug('window.open', url, frameName, features);
-  if (!url) {
-    // The service hasn't yet supplied a URL (as used in Skype).
-    // Return a new dummy window object and wait for the service to change the properties
-    const newWindow = {
-      location: {
-        href: '',
-      },
-    };
-
-    const checkInterval = setInterval(() => {
-      // Has the service changed the URL yet?
-      if (newWindow.location.href !== '') {
-        if (features) {
-          originalWindowOpen(newWindow.location.href, frameName, features);
-        } else {
-          // Open the new URL
-          ipcRenderer.sendToHost('new-window', newWindow.location.href);
-        }
-        clearInterval(checkInterval);
-      }
-    }, 0);
-
-    setTimeout(() => {
-      // Stop checking for location changes after 1 second
-      clearInterval(checkInterval);
-    }, 1000);
-
-    return newWindow as Window;
-  }
-
-  // We need to differentiate if the link should be opened in a popup or in the systems default browser
-  if (!frameName && !features && typeof features !== 'string') {
-    ipcRenderer.sendToHost('new-window', url);
-    return null;
-  }
-
-  if (url) {
-    return originalWindowOpen(url, frameName, features);
-  }
-  return null;
-};
-
 // We can't override APIs here, so we first expose functions via 'window.ferdium',
 // then overwrite the corresponding field of the window object by injected JS.
 contextBridge.exposeInMainWorld('ferdium', {
-  open: window.open,
+  // Called by the page-world window.open replacement (see windowOpenShim.ts)
+  // for URLs that belong in the user's default browser. Real popups never
+  // come through here: they are created natively so the page keeps a genuine
+  // WindowProxy, and the main process' window open handler routes them.
+  open: (url: string) => {
+    debug('window.open (external)', url);
+    if (typeof url === 'string' && url !== '') {
+      ipcRenderer.sendToHost('new-window', url);
+    }
+  },
   setBadge: (
     direct: string | number | null | undefined,
     indirect: string | number | null | undefined,

--- a/src/webview/windowOpenShim.ts
+++ b/src/webview/windowOpenShim.ts
@@ -1,7 +1,49 @@
-// Source of the window.open replacement injected into a service's page
-// world. window.ferdium.open is a contextBridge function, so a URL object
-// passed to window.open would cross the bridge as {} and Chromium would
-// then open "[object Object]"; stringify it here, in the page world,
-// before it reaches the bridge. null/undefined are left as they are.
-export const windowOpenShim =
-  'window.open = (url, frameName, features) => window.ferdium.open(url == null ? url : String(url), frameName, features);';
+// Source of the window.open replacement that recipe.ts injects into a
+// service's page world (see the 'inject-js-unsafe' IPC message).
+//
+// The routing decision has to be made in the page world, and windows the page
+// actually wants have to be created with the page's own native window.open.
+// A WindowProxy cannot cross the contextBridge: it arrives on the other side
+// as a detached plain-object snapshot, so `popup.document`, `popup.closed`
+// and friends are dead. Services rely on the genuine handle. Slack, for
+// example, renders its huddle / screen-share window into the popup's document
+// from the opener and closes the window again when that fails, which is why
+// the huddle window used to flash up and disappear (ferdium-app#788).
+//
+// Only the "open in the default browser" path goes through window.ferdium.open.
+// That is a contextBridge function, so the URL is stringified here first; a
+// URL object would otherwise arrive as {} and Chromium would open
+// "[object Object]".
+export const windowOpenShim = `(() => {
+  const nativeOpen = window.open;
+  const isNonEmptyString = value => typeof value === 'string' && value !== '';
+  const openExternally = url => window.ferdium.open(String(url));
+
+  window.open = function open(url, frameName, features) {
+    // A target name or window features means the page wants a real window
+    // (OAuth popup, Slack huddle window, ...). Let Chromium create it so the
+    // page keeps a real WindowProxy; the main process decides whether the
+    // request becomes a popup window or goes to the default browser.
+    if (isNonEmptyString(frameName) || isNonEmptyString(features)) {
+      return nativeOpen.call(window, url, frameName, features);
+    }
+
+    // A bare window.open(url) is a link, not a window: open it externally.
+    if (url != null && String(url) !== '') {
+      openExternally(url);
+      return null;
+    }
+
+    // No URL and no features (used by e.g. Skype): hand back a placeholder and
+    // forward the URL to the default browser once the page has assigned it.
+    const placeholder = { location: { href: '' } };
+    const poll = setInterval(() => {
+      if (placeholder.location.href !== '') {
+        clearInterval(poll);
+        openExternally(placeholder.location.href);
+      }
+    }, 0);
+    setTimeout(() => clearInterval(poll), 1000);
+    return placeholder;
+  };
+})();`;

--- a/test/electron/popupWindowOptions.test.ts
+++ b/test/electron/popupWindowOptions.test.ts
@@ -1,7 +1,6 @@
 import {
   parseWindowFeatures,
   popupWindowOptions,
-  windowOpenFeaturesAllowResizable,
 } from '../../src/electron/popupWindowOptions';
 
 // What Slack's openHuddleWindowMva hands to window.open() (Electron options
@@ -27,24 +26,6 @@ describe('parseWindowFeatures', () => {
   });
 });
 
-describe('windowOpenFeaturesAllowResizable', () => {
-  it('is resizable by default', () => {
-    expect(windowOpenFeaturesAllowResizable('')).toBe(true);
-    expect(windowOpenFeaturesAllowResizable()).toBe(true);
-    expect(windowOpenFeaturesAllowResizable('width=380,height=272')).toBe(true);
-    expect(windowOpenFeaturesAllowResizable('resizable=yes')).toBe(true);
-    expect(windowOpenFeaturesAllowResizable('resizable')).toBe(true);
-  });
-
-  it('honours an explicit opt-out', () => {
-    expect(windowOpenFeaturesAllowResizable('resizable=no')).toBe(false);
-    expect(windowOpenFeaturesAllowResizable('width=1,resizable=0')).toBe(false);
-    expect(windowOpenFeaturesAllowResizable('resizable=false,width=1')).toBe(
-      false,
-    );
-  });
-});
-
 describe('popupWindowOptions', () => {
   it('always shows the popup and keeps it a normal window', () => {
     const options = popupWindowOptions(SLACK_HUDDLE_FEATURES, onScreen);
@@ -53,7 +34,6 @@ describe('popupWindowOptions', () => {
       alwaysOnTop: false,
       fullscreen: false,
       fullscreenable: true,
-      resizable: true,
       frame: true,
       transparent: false,
       skipTaskbar: false,
@@ -81,8 +61,10 @@ describe('popupWindowOptions', () => {
     });
   });
 
-  it('respects a resizable opt-out', () => {
-    expect(popupWindowOptions('resizable=no', onScreen).resizable).toBe(false);
+  it('leaves resizable handling to Electron', () => {
+    const options = popupWindowOptions('resizable=no', onScreen);
+
+    expect(options).not.toHaveProperty('resizable');
   });
 
   it('leaves an on-screen position alone', () => {

--- a/test/electron/popupWindowOptions.test.ts
+++ b/test/electron/popupWindowOptions.test.ts
@@ -1,0 +1,113 @@
+import {
+  parseWindowFeatures,
+  popupWindowOptions,
+  windowOpenFeaturesAllowResizable,
+} from '../../src/electron/popupWindowOptions';
+
+// What Slack's openHuddleWindowMva hands to window.open() (Electron options
+// serialised as window features).
+const SLACK_HUDDLE_FEATURES =
+  'height=600,width=800,minHeight=400,minWidth=560,alwaysOnTop=yes,title=Huddle,fullscreenable=no,fullscreen=no,show=no,useContentSize=yes,windowId=huddles-T123-C456';
+
+const onScreen = () => true;
+const offScreen = () => false;
+
+describe('parseWindowFeatures', () => {
+  it('parses comma separated key=value pairs', () => {
+    expect(parseWindowFeatures('width=380, height=272 ,popup')).toStrictEqual({
+      width: '380',
+      height: '272',
+      popup: undefined,
+    });
+  });
+
+  it('handles empty and missing input', () => {
+    expect(parseWindowFeatures('')).toStrictEqual({});
+    expect(parseWindowFeatures()).toStrictEqual({});
+  });
+});
+
+describe('windowOpenFeaturesAllowResizable', () => {
+  it('is resizable by default', () => {
+    expect(windowOpenFeaturesAllowResizable('')).toBe(true);
+    expect(windowOpenFeaturesAllowResizable()).toBe(true);
+    expect(windowOpenFeaturesAllowResizable('width=380,height=272')).toBe(true);
+    expect(windowOpenFeaturesAllowResizable('resizable=yes')).toBe(true);
+    expect(windowOpenFeaturesAllowResizable('resizable')).toBe(true);
+  });
+
+  it('honours an explicit opt-out', () => {
+    expect(windowOpenFeaturesAllowResizable('resizable=no')).toBe(false);
+    expect(windowOpenFeaturesAllowResizable('width=1,resizable=0')).toBe(false);
+    expect(windowOpenFeaturesAllowResizable('resizable=false,width=1')).toBe(
+      false,
+    );
+  });
+});
+
+describe('popupWindowOptions', () => {
+  it('always shows the popup and keeps it a normal window', () => {
+    const options = popupWindowOptions(SLACK_HUDDLE_FEATURES, onScreen);
+    expect(options).toMatchObject({
+      show: true,
+      alwaysOnTop: false,
+      fullscreen: false,
+      fullscreenable: true,
+      resizable: true,
+      frame: true,
+      transparent: false,
+      skipTaskbar: false,
+      focusable: true,
+      kiosk: false,
+      modal: false,
+      opacity: 1,
+    });
+  });
+
+  it('does not let a page control window chrome through features', () => {
+    const options = popupWindowOptions(
+      'frame=no,transparent=yes,skipTaskbar=yes,focusable=no,kiosk=yes,opacity=0,alwaysOnTop=1,show=0',
+      onScreen,
+    );
+    expect(options).toMatchObject({
+      show: true,
+      frame: true,
+      transparent: false,
+      skipTaskbar: false,
+      focusable: true,
+      kiosk: false,
+      opacity: 1,
+      alwaysOnTop: false,
+    });
+  });
+
+  it('respects a resizable opt-out', () => {
+    expect(popupWindowOptions('resizable=no', onScreen).resizable).toBe(false);
+  });
+
+  it('leaves an on-screen position alone', () => {
+    const options = popupWindowOptions('x=100,y=200', onScreen);
+    expect('x' in options).toBe(false);
+    expect('y' in options).toBe(false);
+  });
+
+  it('drops an off-screen position so Electron centers the window', () => {
+    const options = popupWindowOptions('x=-5000,y=200', offScreen);
+    expect('x' in options).toBe(true);
+    expect(options.x).toBeUndefined();
+    expect(options.y).toBeUndefined();
+  });
+
+  it('understands the browser style left/top features', () => {
+    const isPositionOnScreen = jest.fn(() => false);
+    popupWindowOptions('left=10,top=20', isPositionOnScreen);
+    expect(isPositionOnScreen).toHaveBeenCalledWith({ x: 10, y: 20 });
+  });
+
+  it('does not check the position when it is incomplete', () => {
+    const isPositionOnScreen = jest.fn(() => false);
+    const options = popupWindowOptions('x=10', isPositionOnScreen);
+    expect(isPositionOnScreen).not.toHaveBeenCalled();
+    expect('x' in options).toBe(false);
+  });
+});

--- a/test/webview/windowOpenShim.test.ts
+++ b/test/webview/windowOpenShim.test.ts
@@ -2,44 +2,128 @@ import { runInNewContext } from 'node:vm';
 
 import { windowOpenShim } from '../../src/webview/windowOpenShim';
 
+const NATIVE_RESULT = { native: true };
+
 function installShim() {
-  const open = jest.fn();
+  const external = jest.fn();
+  const nativeOpen = jest.fn<unknown, unknown[]>(() => NATIVE_RESULT);
   const window: {
     ferdium: { open: jest.Mock };
-    open?: (...args: unknown[]) => unknown;
-  } = { ferdium: { open } };
-  runInNewContext(`"use strict"; (() => { ${windowOpenShim} })();`, { window });
-  return { open, windowOpen: window.open! };
+    open: (...args: unknown[]) => unknown;
+  } = { ferdium: { open: external }, open: nativeOpen };
+  runInNewContext(`"use strict"; (() => { ${windowOpenShim} })();`, {
+    window,
+    setInterval,
+    clearInterval,
+    setTimeout,
+  });
+  return { external, nativeOpen, windowOpen: window.open };
 }
 
+const flushTimers = () =>
+  new Promise(resolve => {
+    setTimeout(resolve, 20);
+  });
+
 describe('windowOpenShim', () => {
-  it('stringifies a URL object before it reaches ferdium.open', () => {
-    const { open, windowOpen } = installShim();
-    windowOpen(new URL('https://example.com/path?x=1'), '_blank', 'noopener');
-    expect(open).toHaveBeenCalledWith(
-      'https://example.com/path?x=1',
-      '_blank',
-      'noopener',
-    );
+  it('replaces window.open', () => {
+    const { nativeOpen, windowOpen } = installShim();
+    expect(windowOpen).not.toBe(nativeOpen);
   });
 
-  it('passes a string url through unchanged', () => {
-    const { open, windowOpen } = installShim();
-    windowOpen('https://example.com/', '_blank');
-    expect(open).toHaveBeenCalledWith(
-      'https://example.com/',
-      '_blank',
-      undefined,
-    );
+  describe('when the page asks for a window', () => {
+    it('opens natively when window features are given and returns the real result', () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      const result = windowOpen(
+        'about:blank',
+        undefined,
+        'width=380,height=272,left=100,top=100',
+      );
+      expect(nativeOpen).toHaveBeenCalledWith(
+        'about:blank',
+        undefined,
+        'width=380,height=272,left=100,top=100',
+      );
+      expect(result).toBe(NATIVE_RESULT);
+      expect(external).not.toHaveBeenCalled();
+    });
+
+    it('opens natively when a target name is given', () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      windowOpen('https://example.com/', '_blank');
+      expect(nativeOpen).toHaveBeenCalledWith(
+        'https://example.com/',
+        '_blank',
+        undefined,
+      );
+      expect(external).not.toHaveBeenCalled();
+    });
+
+    it('opens natively without a url when features are given', () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      const result = windowOpen('', 'huddle', 'width=380,height=272');
+      expect(nativeOpen).toHaveBeenCalledWith(
+        '',
+        'huddle',
+        'width=380,height=272',
+      );
+      expect(result).toBe(NATIVE_RESULT);
+      expect(external).not.toHaveBeenCalled();
+    });
+
+    it('does not stringify the url before handing it to the native window.open', () => {
+      const { nativeOpen, windowOpen } = installShim();
+      const url = new URL('https://example.com/path?x=1');
+      windowOpen(url, undefined, 'popup');
+      expect(nativeOpen.mock.calls[0][0]).toBe(url);
+    });
   });
 
-  it('leaves undefined and null urls untouched', () => {
-    const { open, windowOpen } = installShim();
-    windowOpen();
-    windowOpen(null);
-    expect(open.mock.calls).toStrictEqual([
-      [undefined, undefined, undefined],
-      [null, undefined, undefined],
-    ]);
+  describe('when the page opens a plain url', () => {
+    it('opens it externally and returns null', () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      const result = windowOpen('https://example.com/');
+      expect(external).toHaveBeenCalledWith('https://example.com/');
+      expect(nativeOpen).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('stringifies a URL object before it reaches ferdium.open', () => {
+      const { external, windowOpen } = installShim();
+      windowOpen(new URL('https://example.com/path?x=1'));
+      expect(external).toHaveBeenCalledWith('https://example.com/path?x=1');
+    });
+
+    it('treats an empty features string like no features', () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      windowOpen('https://example.com/', '', '');
+      expect(external).toHaveBeenCalledWith('https://example.com/');
+      expect(nativeOpen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the page opens a window without a url or features', () => {
+    it('returns a placeholder and opens the url externally once assigned', async () => {
+      const { external, nativeOpen, windowOpen } = installShim();
+      const placeholder = windowOpen() as { location: { href: string } };
+      // The placeholder is created inside the vm context, so compare by value.
+      expect(placeholder).toEqual({ location: { href: '' } });
+      expect(external).not.toHaveBeenCalled();
+
+      placeholder.location.href = 'https://example.com/from-placeholder';
+      await flushTimers();
+
+      expect(external).toHaveBeenCalledWith(
+        'https://example.com/from-placeholder',
+      );
+      expect(nativeOpen).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the url is never assigned', async () => {
+      const { external, windowOpen } = installShim();
+      windowOpen(null);
+      await flushTimers();
+      expect(external).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Two independent bugs prevented Slack huddle windows from working in Ferdium. Neither is in the recipe.

**1. The popup handle never reached the page.** The service preload replaces the page's `window.open` with a shim that calls `window.ferdium.open`, a `contextBridge` function. Since #2412 the popup is created, but a `WindowProxy` cannot cross the context bridge: the page gets a detached plain-object snapshot (`[object Object]`, `document.documentElement` undefined). Slack doesn't load a URL in its huddle window; `openManagedChildWindow` opens `about:blank` with size features and renders the huddle UI into `popup.document` from the opener. That throws on the snapshot, Slack's cleanup calls `popup.close()`, and the window flashes and disappears. Slack's console shows `Attempted to window.open but received falsey return value` / `Unable to create window`.

Fix: the routing decision now happens in the page world (`src/webview/windowOpenShim.ts`). Any `window.open` call with a target name or window features uses the page's native `window.open` and returns the real `WindowProxy`; the main process handler still decides whether it becomes a popup (`new-window`) or is sent to the default browser (`foreground-tab`). A bare `window.open(url)` still goes to the default browser via `ferdium.open`, with URL objects stringified as before. The Skype-style `window.open()` placeholder keeps working, and now actually sees the page's `location.href` assignment because it lives in the page world. The preload no longer patches its own `window.open`.

**2. Joined huddles opened an invisible window.** When you join a huddle someone else started, Slack's `openHuddleWindowMva` puts Electron options in the features string: `show=no,alwaysOnTop=yes,fullscreenable=no,title=Huddle,...`. Browsers ignore these; Slack's desktop app shows the window later via its own bridge. Electron parses every `key=value` feature into a `BrowserWindow` option, so Ferdium created the huddle window hidden and always-on-top, and "Bring huddle to front" (`popup.focus()`) can't surface a window that was never shown. You hear the huddle but can't see it.

Fix: new `src/electron/popupWindowOptions.ts` normalises popup options so a service popup always behaves like a browser popup: shown, never always-on-top / frameless / transparent / kiosk / modal / skip-taskbar, fullscreenable, resizable unless the page says `resizable=no`, and a remembered off-screen position is dropped so Electron centres the window. Both window-open handlers in `src/index.ts` use it.

Other changes in `src/index.ts`:

- Popups are standalone windows rather than children of the main window, so a huddle / shared screen can be moved to another display, maximised or made fullscreen, and stays visible while Ferdium is hidden or minimised.
- Popups default to resizable. Electron 38+ made `window.open` popups resizable per the WHATWG spec; the helper from #2469 restored the old fixed-size default, which leaves Slack's huddle window unresizable because Slack never requests `resizable`.
- `foreground-tab` links inside popups open in the default browser instead of being silently dropped.

`alwaysOnTop` is deliberately not honoured: Slack asks for it because its desktop app floats the huddle window, but a web page shouldn't get an OS-level always-on-top window. "Bring huddle to front" covers that.

#### Motivation and Context

Fixes #788, #1014
Closes #2299
Related: #974, #533

Slack huddles and screen sharing have been unusable in Ferdium for years

#### Checklist

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`pnpm prepare-code`)
- [x] `pnpm test` passes
- [x] I tested/previewed my changes locally

Tested on macOS (Apple Silicon) against a real Slack workspace: starting a huddle and opening the huddle window works, and joining a huddle started by someone else now shows the window, with "Bring huddle to front" raising it. Also verified in a minimal Electron 44 harness mirroring Ferdium's webview setup, with Ferdium's built `recipe.js` preload and Slack's exact feature strings: before, the page gets `[object Object]` and the popup is closed, and the joined-huddle window reports `visible: false, alwaysOnTop: true` even after `focus()`; after, the page gets `[object Window]`, `document.write` and rendering into the popup succeed, and the window is visible, not always-on-top, resizable and fullscreenable. Plain links, URL objects, `_blank` targets and the empty-argument placeholder all still open in the default browser. Unit tests added for the shim routing and the option sanitising.

#### Release Notes

Fixed Slack huddle and screen-share windows: popups opened by services now receive a real window handle and are always shown, so the huddle window opens and stays visible instead of flashing and closing.
